### PR TITLE
HTTP-API Endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,189 @@
 version = 3
 
 [[package]]
+name = "actix-codec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a"
+dependencies = [
+ "bitflags 2.4.1",
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "actix-http"
+version = "3.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44cceded2fb55f3c4b67068fa64962e2ca59614edc5b03167de9ff82ae803da0"
+dependencies = [
+ "actix-codec",
+ "actix-rt",
+ "actix-service",
+ "actix-utils",
+ "base64 0.22.1",
+ "bitflags 2.4.1",
+ "brotli",
+ "bytes",
+ "bytestring",
+ "derive_more",
+ "encoding_rs",
+ "flate2",
+ "foldhash",
+ "futures-core",
+ "h2",
+ "http 0.2.11",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "language-tags",
+ "local-channel",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rand 0.9.4",
+ "sha1",
+ "smallvec",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "zstd 0.13.0",
+]
+
+[[package]]
+name = "actix-macros"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
+dependencies = [
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "actix-router"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14f8c75c51892f18d9c46150c5ac7beb81c95f78c8b83a634d49f4ca32551fe7"
+dependencies = [
+ "bytestring",
+ "cfg-if",
+ "http 0.2.11",
+ "regex",
+ "regex-lite",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "actix-rt"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92589714878ca59a7626ea19734f0e07a6a875197eec751bb5d3f99e64998c63"
+dependencies = [
+ "futures-core",
+ "tokio",
+]
+
+[[package]]
+name = "actix-server"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a65064ea4a457eaf07f2fba30b4c695bf43b721790e9530d26cb6f9019ff7502"
+dependencies = [
+ "actix-rt",
+ "actix-service",
+ "actix-utils",
+ "futures-core",
+ "futures-util",
+ "mio",
+ "socket2 0.5.5",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "actix-service"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e46f36bf0e5af44bdc4bdb36fbbd421aa98c79a9bce724e1edeb3894e10dc7f"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "actix-utils"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a1dcdff1466e3c2488e1cb5c36a71822750ad43839937f85d2f4d9f8b705d8"
+dependencies = [
+ "local-waker",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "actix-web"
+version = "4.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2e3b15b3dc6c6ed996e4032389e9849d4ab002b1e92fbfe85b5f307d1479b4d"
+dependencies = [
+ "actix-codec",
+ "actix-http",
+ "actix-macros",
+ "actix-router",
+ "actix-rt",
+ "actix-server",
+ "actix-service",
+ "actix-utils",
+ "actix-web-codegen",
+ "bytes",
+ "bytestring",
+ "cfg-if",
+ "cookie 0.16.2",
+ "derive_more",
+ "encoding_rs",
+ "foldhash",
+ "futures-core",
+ "futures-util",
+ "impl-more",
+ "itoa",
+ "language-tags",
+ "log",
+ "mime",
+ "once_cell",
+ "pin-project-lite",
+ "regex",
+ "regex-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "smallvec",
+ "socket2 0.5.5",
+ "time",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "actix-web-codegen"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f591380e2e68490b5dfaf1dd1aa0ebe78d84ba7067078512b4ea6e4492d622b8"
+dependencies = [
+ "actix-router",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -46,6 +229,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
+dependencies = [
+ "alloc-no-stdlib",
 ]
 
 [[package]]
@@ -239,6 +437,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,6 +555,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "brotli"
+version = "8.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -400,6 +625,15 @@ name = "bytes"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+
+[[package]]
+name = "bytestring"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86566c496f2f47d9b8147a4c8b02ffdb69c919fe0c2b2e7195d22cbba0e635c9"
+dependencies = [
+ "bytes",
+]
 
 [[package]]
 name = "bzip2"
@@ -565,6 +799,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "cookie"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -669,7 +912,7 @@ dependencies = [
  "log",
  "tar",
  "xz2",
- "zstd",
+ "zstd 0.11.2+zstd.1.5.2",
 ]
 
 [[package]]
@@ -679,6 +922,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eb30d70a07a3b04884d2677f06bec33509dc67ca60d92949e5535352d3191dc"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.90",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -908,6 +1174,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -1445,6 +1717,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-more"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a5a9a0ff0086c7a148acb942baaabeadf9504d10400b5a05645853729b9cd2"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1614,9 +1892,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libredox"
@@ -1640,6 +1918,23 @@ name = "litemap"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+
+[[package]]
+name = "local-channel"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6cbc85e69b8df4b8bb8b89ec634e7189099cea8927a276b7384ce5488e53ec8"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "local-waker",
+]
+
+[[package]]
+name = "local-waker"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d873d7c67ce09b42110d801813efbc9364414e356be9935700d368351657487"
 
 [[package]]
 name = "lock_api"
@@ -1726,13 +2021,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.11"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
+ "log",
  "wasi",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1786,16 +2082,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi",
- "libc",
 ]
 
 [[package]]
@@ -1930,7 +2216,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
 dependencies = [
  "base64ct",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -2009,7 +2295,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be97d76faf1bfab666e1375477b23fde79eccf0276e9b63b92a39d676a889ba9"
 dependencies = [
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -2114,8 +2400,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2125,7 +2421,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2135,6 +2441,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.11",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -2188,6 +2503,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"
@@ -2316,7 +2637,7 @@ checksum = "17dd00bff1d737c40dbcd47d4375281bf4c17933f9eef0a185fc7bacca23ecbd"
 dependencies = [
  "anyhow",
  "chrono",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -2381,7 +2702,7 @@ dependencies = [
  "borsh",
  "bytes",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "rkyv",
  "serde",
  "serde_json",
@@ -2502,6 +2823,7 @@ dependencies = [
 name = "sdl"
 version = "0.2.1"
 dependencies = [
+ "actix-web",
  "aes",
  "anyhow",
  "async-compression",
@@ -2529,7 +2851,7 @@ dependencies = [
  "once_cell",
  "pathsearch",
  "portpicker",
- "rand",
+ "rand 0.8.5",
  "regex",
  "reqwest",
  "reqwest-middleware",
@@ -2537,6 +2859,7 @@ dependencies = [
  "reqwest-retry",
  "rust-lapper",
  "selenium-manager",
+ "serde",
  "serde_json",
  "thirtyfour",
  "tokio",
@@ -2767,6 +3090,16 @@ checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
 dependencies = [
  "libc",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3029,28 +3362,26 @@ checksum = "c7c4ceeeca15c8384bbc3e011dbd8fccb7f068a440b752b7d9b32ceb0ca0e2e8"
 
 [[package]]
 name = "tokio"
-version = "1.35.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d45b238a16291a4e1584e61820b8ae57d696cc5015c459c229ccc6990cc1c"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
- "backtrace",
  "bytes",
  "libc",
  "mio",
- "num_cpus",
  "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.5",
+ "socket2 0.6.4",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.2.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3160,6 +3491,7 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3223,6 +3555,12 @@ name = "unicode-width"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
@@ -3487,6 +3825,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-sys"
 version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3511,6 +3855,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets 0.52.0",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -3834,7 +4187,7 @@ dependencies = [
  "pbkdf2",
  "sha1",
  "time",
- "zstd",
+ "zstd 0.11.2+zstd.1.5.2",
 ]
 
 [[package]]
@@ -3852,7 +4205,16 @@ version = "0.11.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
 dependencies = [
- "zstd-safe",
+ "zstd-safe 5.0.2+zstd.1.5.2",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bffb3309596d527cfcba7dfc6ed6052f1d39dfbd7c867aa2e865e4a449c10110"
+dependencies = [
+ "zstd-safe 7.0.0",
 ]
 
 [[package]]
@@ -3862,6 +4224,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
 dependencies = [
  "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43747c7422e2924c11144d5229878b98180ef8b06cca4ab5af37afc8a8d8ea3e"
+dependencies = [
  "zstd-sys",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,10 +51,16 @@ log = "0.4"
 env_logger = "0.10"
 chrono = "0.4"
 anyhow = "1.0"
+actix-web = "4"
+serde = { version = "1", features = ["derive"] }
 
 [[bin]]
 name = "sdl"
 path = "src/main.rs"
+
+[[bin]]
+name = "sdl-api"
+path = "src/bin/sdl-api.rs"
 
 [lib]
 name = "sdl"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Download multiple episodes from streaming sites
 
 ## Supported extractors
 * Doodstream
-* Filemoon
+* Filemoon 
 * LoadX
 * Speedfiles
 * Streamtape

--- a/src/api/browser.rs
+++ b/src/api/browser.rs
@@ -1,0 +1,101 @@
+//! API-specific browser lifecycle management.
+//!
+//! The API keeps a single shared Selenium/Chrome browser behind a Tokio mutex.
+//! This serializes scraper access while avoiding one ChromeDriver process per
+//! request. `AniWorldSerienStream` and the related series downloaders require a
+//! `thirtyfour::WebDriver` because AniWorld/SerienStream render the relevant
+//! page contents in a real browser/Selenium session.
+
+use std::process::Child;
+
+use anyhow::Context;
+use futures_util::future::LocalBoxFuture;
+use tokio::sync::Mutex;
+
+use crate::api::sdl_wrapper::api_log_wrapper;
+use crate::{chrome, dirs, download};
+
+/// Shared browser manager for API requests.
+pub struct ApiBrowser {
+    inner: Mutex<Option<ManagedBrowser>>,
+}
+
+struct ManagedBrowser {
+    driver: thirtyfour::WebDriver,
+    chromedriver: Child,
+}
+
+impl std::fmt::Debug for ApiBrowser {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.debug_struct("ApiBrowser").finish_non_exhaustive()
+    }
+}
+
+impl ApiBrowser {
+    pub fn new() -> Self {
+        Self {
+            inner: Mutex::new(None),
+        }
+    }
+
+    /// Run an operation with the shared API WebDriver.
+    ///
+    /// Access is serialized by the manager's mutex because the downloader stack
+    /// navigates pages and executes scripts on a single browser session.
+    pub async fn with_driver<T, F>(&self, operation: F) -> Result<T, anyhow::Error>
+    where
+        F: for<'driver> FnOnce(&'driver thirtyfour::WebDriver) -> LocalBoxFuture<'driver, Result<T, anyhow::Error>>,
+    {
+        let mut guard = self.inner.lock().await;
+        if guard.is_none() {
+            *guard = Some(Self::start_browser().await?);
+        }
+
+        let browser = guard.as_ref().context("api browser is unavailable")?;
+        operation(&browser.driver).await
+    }
+
+    pub async fn get_user_agent(&self) -> Result<Option<String>, anyhow::Error> {
+        self.with_driver(|driver| Box::pin(async move { Ok(chrome::get_user_agent(driver).await) }))
+            .await
+    }
+
+    /// Shut down Selenium cleanly and terminate the ChromeDriver process.
+    pub async fn shutdown(&self) {
+        let Some(mut browser) = self.inner.lock().await.take() else {
+            return;
+        };
+
+        if let Err(err) = browser.driver.quit().await {
+            log::warn!("Failed to quit API browser session: {err:#}");
+        }
+        if let Err(err) = browser.chromedriver.kill() {
+            log::warn!("Failed to terminate API ChromeDriver process: {err}");
+        }
+        let _ = browser.chromedriver.wait();
+    }
+
+    async fn start_browser() -> Result<ManagedBrowser, anyhow::Error> {
+        let data_dir = dirs::get_data_dir().await?;
+        let limiter = async_speed_limit::Limiter::new(f64::INFINITY);
+        let asset_downloader = {
+            let mut log_wrapper = api_log_wrapper()?;
+            download::Downloader::new(
+                log_wrapper.as_mut().expect("api log wrapper initialized"),
+                limiter,
+                false,
+                None,
+                None,
+                None,
+            )
+        };
+        let (driver, chromedriver) = chrome::ChromeDriver::get(&data_dir, &asset_downloader, true).await?;
+        Ok(ManagedBrowser { driver, chromedriver })
+    }
+}
+
+impl Default for ApiBrowser {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/api/error.rs
+++ b/src/api/error.rs
@@ -1,0 +1,45 @@
+use actix_web::{http::StatusCode, HttpResponse, ResponseError};
+use serde::Serialize;
+
+#[derive(Debug)]
+pub enum ApiError {
+    BadRequest(String),
+    NotFound(String),
+    Internal(anyhow::Error),
+}
+
+#[derive(Debug, Serialize)]
+struct ErrorBody<'a> {
+    error: &'a str,
+}
+
+impl std::fmt::Display for ApiError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::BadRequest(message) | Self::NotFound(message) => f.write_str(message),
+            Self::Internal(err) => write!(f, "{err:#}"),
+        }
+    }
+}
+
+impl ResponseError for ApiError {
+    fn status_code(&self) -> StatusCode {
+        match self {
+            Self::BadRequest(_) => StatusCode::BAD_REQUEST,
+            Self::NotFound(_) => StatusCode::NOT_FOUND,
+            Self::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+
+    fn error_response(&self) -> HttpResponse {
+        HttpResponse::build(self.status_code()).json(ErrorBody {
+            error: &self.to_string(),
+        })
+    }
+}
+
+impl From<anyhow::Error> for ApiError {
+    fn from(value: anyhow::Error) -> Self {
+        Self::Internal(value)
+    }
+}

--- a/src/api/error.rs
+++ b/src/api/error.rs
@@ -4,23 +4,44 @@ use serde::Serialize;
 #[derive(Debug)]
 pub enum ApiError {
     BadRequest(String),
-    NotFound(String),
+    UnsupportedUrl(String),
+    ExtractorFailed(String),
+    UpstreamFailed(String),
+    Timeout(String),
     ServiceUnavailable(String),
-    Internal(anyhow::Error),
+    Internal(String),
 }
 
 #[derive(Debug, Serialize)]
 struct ErrorBody<'a> {
     error: &'a str,
+    code: &'a str,
+}
+
+impl ApiError {
+    fn code(&self) -> &'static str {
+        match self {
+            Self::BadRequest(_) => "bad_request",
+            Self::UnsupportedUrl(_) => "unsupported_url",
+            Self::ExtractorFailed(_) => "extractor_failed",
+            Self::UpstreamFailed(_) => "upstream_failed",
+            Self::Timeout(_) => "timeout",
+            Self::ServiceUnavailable(_) => "service_unavailable",
+            Self::Internal(_) => "internal",
+        }
+    }
 }
 
 impl std::fmt::Display for ApiError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::BadRequest(message) | Self::NotFound(message) | Self::ServiceUnavailable(message) => {
-                f.write_str(message)
-            }
-            Self::Internal(err) => write!(f, "{err:#}"),
+            Self::BadRequest(message)
+            | Self::UnsupportedUrl(message)
+            | Self::ExtractorFailed(message)
+            | Self::UpstreamFailed(message)
+            | Self::Timeout(message)
+            | Self::ServiceUnavailable(message)
+            | Self::Internal(message) => f.write_str(message),
         }
     }
 }
@@ -29,7 +50,9 @@ impl ResponseError for ApiError {
     fn status_code(&self) -> StatusCode {
         match self {
             Self::BadRequest(_) => StatusCode::BAD_REQUEST,
-            Self::NotFound(_) => StatusCode::NOT_FOUND,
+            Self::UnsupportedUrl(_) => StatusCode::NOT_FOUND,
+            Self::ExtractorFailed(_) | Self::UpstreamFailed(_) => StatusCode::BAD_GATEWAY,
+            Self::Timeout(_) => StatusCode::GATEWAY_TIMEOUT,
             Self::ServiceUnavailable(_) => StatusCode::SERVICE_UNAVAILABLE,
             Self::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
         }
@@ -38,12 +61,14 @@ impl ResponseError for ApiError {
     fn error_response(&self) -> HttpResponse {
         HttpResponse::build(self.status_code()).json(ErrorBody {
             error: &self.to_string(),
+            code: self.code(),
         })
     }
 }
 
 impl From<anyhow::Error> for ApiError {
     fn from(value: anyhow::Error) -> Self {
-        Self::Internal(value)
+        log::error!("Internal API error: {value:#}");
+        Self::Internal("internal server error".to_owned())
     }
 }

--- a/src/api/error.rs
+++ b/src/api/error.rs
@@ -5,6 +5,7 @@ use serde::Serialize;
 pub enum ApiError {
     BadRequest(String),
     NotFound(String),
+    ServiceUnavailable(String),
     Internal(anyhow::Error),
 }
 
@@ -16,7 +17,9 @@ struct ErrorBody<'a> {
 impl std::fmt::Display for ApiError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::BadRequest(message) | Self::NotFound(message) => f.write_str(message),
+            Self::BadRequest(message) | Self::NotFound(message) | Self::ServiceUnavailable(message) => {
+                f.write_str(message)
+            }
             Self::Internal(err) => write!(f, "{err:#}"),
         }
     }
@@ -27,6 +30,7 @@ impl ResponseError for ApiError {
         match self {
             Self::BadRequest(_) => StatusCode::BAD_REQUEST,
             Self::NotFound(_) => StatusCode::NOT_FOUND,
+            Self::ServiceUnavailable(_) => StatusCode::SERVICE_UNAVAILABLE,
             Self::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -2,14 +2,14 @@ use actix_web::{web, HttpResponse};
 
 use crate::api::error::ApiError;
 use crate::api::sdl_wrapper;
-use crate::api::types::{HealthResponse, InfoRequest, PlayJson, PlayQuery};
+use crate::api::types::{ApiState, HealthResponse, InfoRequest, PlayJson, PlayQuery};
 
-pub async fn get_play(query: web::Query<PlayQuery>) -> Result<HttpResponse, ApiError> {
-    sdl_wrapper::play(query.into_inner()).await
+pub async fn get_play(state: web::Data<ApiState>, query: web::Query<PlayQuery>) -> Result<HttpResponse, ApiError> {
+    sdl_wrapper::play(state.get_ref().clone(), query.into_inner()).await
 }
 
-pub async fn post_play(payload: web::Json<PlayJson>) -> Result<HttpResponse, ApiError> {
-    sdl_wrapper::play(payload.into_inner()).await
+pub async fn post_play(state: web::Data<ApiState>, payload: web::Json<PlayJson>) -> Result<HttpResponse, ApiError> {
+    sdl_wrapper::play(state.get_ref().clone(), payload.into_inner()).await
 }
 
 pub async fn get_info(query: web::Query<InfoRequest>) -> Result<HttpResponse, ApiError> {

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -1,0 +1,32 @@
+use actix_web::{web, HttpResponse};
+
+use crate::api::error::ApiError;
+use crate::api::sdl_wrapper;
+use crate::api::types::{HealthResponse, InfoRequest, PlayRequest};
+
+pub async fn get_play(query: web::Query<PlayRequest>) -> Result<HttpResponse, ApiError> {
+    let response = sdl_wrapper::play(query.into_inner()).await?;
+    Ok(HttpResponse::Ok().json(response))
+}
+
+pub async fn post_play(payload: web::Json<PlayRequest>) -> Result<HttpResponse, ApiError> {
+    let response = sdl_wrapper::play(payload.into_inner()).await?;
+    Ok(HttpResponse::Ok().json(response))
+}
+
+pub async fn get_info(query: web::Query<InfoRequest>) -> Result<HttpResponse, ApiError> {
+    let response = sdl_wrapper::info(query.into_inner().url).await?;
+    Ok(HttpResponse::Ok().json(response))
+}
+
+pub async fn post_info(payload: web::Json<InfoRequest>) -> Result<HttpResponse, ApiError> {
+    let response = sdl_wrapper::info(payload.into_inner().url).await?;
+    Ok(HttpResponse::Ok().json(response))
+}
+
+pub async fn health() -> HttpResponse {
+    HttpResponse::Ok().json(HealthResponse {
+        name: "sdl-api",
+        routes: &["GET /api/play", "POST /api/play", "GET /api/info", "POST /api/info"],
+    })
+}

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -13,12 +13,12 @@ pub async fn post_play(payload: web::Json<PlayJson>) -> Result<HttpResponse, Api
 }
 
 pub async fn get_info(query: web::Query<InfoRequest>) -> Result<HttpResponse, ApiError> {
-    let response = sdl_wrapper::info(query.into_inner().url).await?;
+    let response = sdl_wrapper::info(query.into_inner()).await?;
     Ok(HttpResponse::Ok().json(response))
 }
 
 pub async fn post_info(payload: web::Json<InfoRequest>) -> Result<HttpResponse, ApiError> {
-    let response = sdl_wrapper::info(payload.into_inner().url).await?;
+    let response = sdl_wrapper::info(payload.into_inner()).await?;
     Ok(HttpResponse::Ok().json(response))
 }
 

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -2,7 +2,9 @@ use actix_web::{web, HttpResponse};
 
 use crate::api::error::ApiError;
 use crate::api::sdl_wrapper;
-use crate::api::types::{ApiState, HealthResponse, InfoRequest, PlayJson, PlayQuery};
+use crate::api::types::{
+    ApiState, DownloadJson, DownloadQuery, HealthResponse, InfoRequest, InfoResolveRequest, PlayJson, PlayQuery,
+};
 
 pub async fn get_play(state: web::Data<ApiState>, query: web::Query<PlayQuery>) -> Result<HttpResponse, ApiError> {
     sdl_wrapper::play(state.get_ref().clone(), query.into_inner()).await
@@ -10,6 +12,20 @@ pub async fn get_play(state: web::Data<ApiState>, query: web::Query<PlayQuery>) 
 
 pub async fn post_play(state: web::Data<ApiState>, payload: web::Json<PlayJson>) -> Result<HttpResponse, ApiError> {
     sdl_wrapper::play(state.get_ref().clone(), payload.into_inner()).await
+}
+
+pub async fn get_download(
+    state: web::Data<ApiState>,
+    query: web::Query<DownloadQuery>,
+) -> Result<HttpResponse, ApiError> {
+    sdl_wrapper::download(state.get_ref().clone(), query.into_inner()).await
+}
+
+pub async fn post_download(
+    state: web::Data<ApiState>,
+    payload: web::Json<DownloadJson>,
+) -> Result<HttpResponse, ApiError> {
+    sdl_wrapper::download(state.get_ref().clone(), payload.into_inner()).await
 }
 
 pub async fn get_info(state: web::Data<ApiState>, query: web::Query<InfoRequest>) -> Result<HttpResponse, ApiError> {
@@ -22,9 +38,41 @@ pub async fn post_info(state: web::Data<ApiState>, payload: web::Json<InfoReques
     Ok(HttpResponse::Ok().json(response))
 }
 
+pub async fn get_info_resolve(
+    state: web::Data<ApiState>,
+    query: web::Query<InfoResolveRequest>,
+) -> Result<HttpResponse, ApiError> {
+    let response = sdl_wrapper::info_resolve(state.get_ref().clone(), query.into_inner()).await?;
+    Ok(HttpResponse::Ok().json(response))
+}
+
+pub async fn post_info_resolve(
+    state: web::Data<ApiState>,
+    payload: web::Json<InfoResolveRequest>,
+) -> Result<HttpResponse, ApiError> {
+    let response = sdl_wrapper::info_resolve(state.get_ref().clone(), payload.into_inner()).await?;
+    Ok(HttpResponse::Ok().json(response))
+}
+
 pub async fn health() -> HttpResponse {
     HttpResponse::Ok().json(HealthResponse {
         name: "sdl-api",
-        routes: &["GET /api/play", "POST /api/play", "GET /api/info", "POST /api/info"],
+        routes: &[
+            "GET /api/play",
+            "POST /api/play",
+            "GET /api/download",
+            "POST /api/download",
+            "GET /api/info",
+            "POST /api/info",
+            "GET /api/info_resolve",
+            "POST /api/info_resolve",
+            "GET /openapi.yaml",
+        ],
     })
+}
+
+pub async fn openapi_yaml() -> HttpResponse {
+    HttpResponse::Ok()
+        .content_type("application/yaml; charset=utf-8")
+        .body(include_str!("openapi.yaml"))
 }

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -2,16 +2,14 @@ use actix_web::{web, HttpResponse};
 
 use crate::api::error::ApiError;
 use crate::api::sdl_wrapper;
-use crate::api::types::{HealthResponse, InfoRequest, PlayRequest};
+use crate::api::types::{HealthResponse, InfoRequest, PlayJson, PlayQuery};
 
-pub async fn get_play(query: web::Query<PlayRequest>) -> Result<HttpResponse, ApiError> {
-    let response = sdl_wrapper::play(query.into_inner()).await?;
-    Ok(HttpResponse::Ok().json(response))
+pub async fn get_play(query: web::Query<PlayQuery>) -> Result<HttpResponse, ApiError> {
+    sdl_wrapper::play(query.into_inner()).await
 }
 
-pub async fn post_play(payload: web::Json<PlayRequest>) -> Result<HttpResponse, ApiError> {
-    let response = sdl_wrapper::play(payload.into_inner()).await?;
-    Ok(HttpResponse::Ok().json(response))
+pub async fn post_play(payload: web::Json<PlayJson>) -> Result<HttpResponse, ApiError> {
+    sdl_wrapper::play(payload.into_inner()).await
 }
 
 pub async fn get_info(query: web::Query<InfoRequest>) -> Result<HttpResponse, ApiError> {

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -12,13 +12,13 @@ pub async fn post_play(state: web::Data<ApiState>, payload: web::Json<PlayJson>)
     sdl_wrapper::play(state.get_ref().clone(), payload.into_inner()).await
 }
 
-pub async fn get_info(query: web::Query<InfoRequest>) -> Result<HttpResponse, ApiError> {
-    let response = sdl_wrapper::info(query.into_inner()).await?;
+pub async fn get_info(state: web::Data<ApiState>, query: web::Query<InfoRequest>) -> Result<HttpResponse, ApiError> {
+    let response = sdl_wrapper::info(state.get_ref().clone(), query.into_inner()).await?;
     Ok(HttpResponse::Ok().json(response))
 }
 
-pub async fn post_info(payload: web::Json<InfoRequest>) -> Result<HttpResponse, ApiError> {
-    let response = sdl_wrapper::info(payload.into_inner()).await?;
+pub async fn post_info(state: web::Data<ApiState>, payload: web::Json<InfoRequest>) -> Result<HttpResponse, ApiError> {
+    let response = sdl_wrapper::info(state.get_ref().clone(), payload.into_inner()).await?;
     Ok(HttpResponse::Ok().json(response))
 }
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -6,6 +6,7 @@
 //! `AniWorldSerienStream::get_series_info`, and `extractors::extract_video_url*`,
 //! keeping API hoster support aligned with the CLI.
 
+pub mod browser;
 pub mod error;
 pub mod handlers;
 pub mod routes;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,0 +1,13 @@
+//! HTTP API surface for SDL.
+//!
+//! The API modules are intentionally thin wrappers around the existing SDL
+//! downloader and extractor stack. They are structured so server routes can
+//! reuse `downloaders::find_downloader_for_url`, `InstantiatedDownloader::download`,
+//! `AniWorldSerienStream::get_series_info`, and `extractors::extract_video_url*`,
+//! keeping API hoster support aligned with the CLI.
+
+pub mod error;
+pub mod handlers;
+pub mod routes;
+pub mod sdl_wrapper;
+pub mod types;

--- a/src/api/openapi.yaml
+++ b/src/api/openapi.yaml
@@ -1,0 +1,305 @@
+openapi: 3.1.1
+info:
+  title: SDL API
+  version: 0.2.1
+  description: Stream, download, inspect, and resolve supported SDL video links.
+servers:
+  - url: http://localhost:8080
+paths:
+  /health:
+    get:
+      operationId: health
+      summary: API health and route list
+      responses:
+        '200':
+          description: Healthy API response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthResponse'
+  /api/play:
+    get:
+      operationId: playFromQuery
+      summary: Stream a playable video inline
+      parameters:
+        - $ref: '#/components/parameters/Url'
+        - $ref: '#/components/parameters/Language'
+        - $ref: '#/components/parameters/VideoType'
+        - $ref: '#/components/parameters/Episodes'
+        - $ref: '#/components/parameters/Seasons'
+        - $ref: '#/components/parameters/Extractor'
+        - $ref: '#/components/parameters/UserAgent'
+        - $ref: '#/components/parameters/Referer'
+      responses:
+        '200':
+          description: Video stream
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+            video/mp4:
+              schema:
+                type: string
+                format: binary
+    post:
+      operationId: play
+      summary: Stream a playable video inline
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PlayRequest'
+      responses:
+        '200':
+          description: Video stream
+  /api/download:
+    get:
+      operationId: downloadFromQuery
+      summary: Download a resolved video as an attachment
+      parameters:
+        - $ref: '#/components/parameters/Url'
+        - $ref: '#/components/parameters/Language'
+        - $ref: '#/components/parameters/VideoType'
+        - $ref: '#/components/parameters/Episodes'
+        - $ref: '#/components/parameters/Seasons'
+        - $ref: '#/components/parameters/Extractor'
+        - $ref: '#/components/parameters/UserAgent'
+        - $ref: '#/components/parameters/Referer'
+      responses:
+        '200':
+          description: Downloadable video response
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+            video/mp4:
+              schema:
+                type: string
+                format: binary
+    post:
+      operationId: download
+      summary: Download a resolved video as an attachment
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PlayRequest'
+      responses:
+        '200':
+          description: Downloadable video response
+  /api/info:
+    get:
+      operationId: infoFromQuery
+      summary: Get metadata for a supported URL
+      parameters:
+        - $ref: '#/components/parameters/Url'
+        - name: resolve_streams
+          in: query
+          schema:
+            type: boolean
+            default: false
+      responses:
+        '200':
+          description: Metadata response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InfoResponse'
+    post:
+      operationId: info
+      summary: Get metadata for a supported URL
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InfoRequest'
+      responses:
+        '200':
+          description: Metadata response
+  /api/info_resolve:
+    get:
+      operationId: infoResolveFromQuery
+      summary: Resolve generic redirect links to their real extractor source
+      parameters:
+        - $ref: '#/components/parameters/Url'
+        - $ref: '#/components/parameters/Extractor'
+        - $ref: '#/components/parameters/UserAgent'
+        - $ref: '#/components/parameters/Referer'
+      responses:
+        '200':
+          description: Resolved link information
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InfoResolveResponse'
+    post:
+      operationId: infoResolve
+      summary: Resolve generic redirect links to their real extractor source
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InfoResolveRequest'
+      responses:
+        '200':
+          description: Resolved link information
+  /openapi.yaml:
+    get:
+      operationId: openapiYaml
+      summary: OpenAPI description
+      responses:
+        '200':
+          description: OpenAPI YAML document
+          content:
+            application/yaml:
+              schema:
+                type: string
+components:
+  parameters:
+    Url:
+      name: url
+      in: query
+      required: true
+      schema:
+        type: string
+        format: uri
+    Language:
+      name: language
+      in: query
+      schema:
+        type: string
+        enum: [unspecified, any, german, english]
+    VideoType:
+      name: video_type
+      in: query
+      schema:
+        type: string
+        enum: [unspecified, any, raw, dub, sub]
+    Episodes:
+      name: episodes
+      in: query
+      schema:
+        type: string
+        description: Single episode, comma/range list, or all.
+    Seasons:
+      name: seasons
+      in: query
+      schema:
+        type: string
+        description: Single season, comma/range list, or all.
+    Extractor:
+      name: extractor
+      in: query
+      schema:
+        type: string
+    UserAgent:
+      name: user_agent
+      in: query
+      schema:
+        type: string
+    Referer:
+      name: referer
+      in: query
+      schema:
+        type: string
+        format: uri
+  schemas:
+    PlayRequest:
+      type: object
+      required: [url]
+      properties:
+        url:
+          type: string
+          format: uri
+        language:
+          type: string
+        video_type:
+          type: string
+        episodes:
+          type: string
+        seasons:
+          type: string
+        extractor_priorities:
+          type: array
+          items:
+            type: string
+        extractor:
+          type: string
+        user_agent:
+          type: string
+        referer:
+          type: string
+          format: uri
+    InfoRequest:
+      type: object
+      required: [url]
+      properties:
+        url:
+          type: string
+          format: uri
+        resolve_streams:
+          type: boolean
+          default: false
+    InfoResolveRequest:
+      type: object
+      required: [url]
+      properties:
+        url:
+          type: string
+          format: uri
+        extractor:
+          type: string
+        user_agent:
+          type: string
+        referer:
+          type: string
+          format: uri
+    InfoResolveResponse:
+      type: object
+      properties:
+        supported:
+          type: boolean
+        input_url:
+          type: string
+        resolved_page_url:
+          type: [string, 'null']
+        video_url:
+          type: [string, 'null']
+        referer:
+          type: [string, 'null']
+        extractor:
+          type: [string, 'null']
+        error:
+          type: [string, 'null']
+    InfoResponse:
+      type: object
+      properties:
+        supported:
+          type: boolean
+        downloader:
+          type: [string, 'null']
+        title:
+          type: [string, 'null']
+        description:
+          type: [string, 'null']
+        status:
+          type: [string, 'null']
+        year:
+          type: [integer, 'null']
+        catalog:
+          type: [object, 'null']
+    HealthResponse:
+      type: object
+      properties:
+        name:
+          type: string
+        routes:
+          type: array
+          items:
+            type: string

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -7,11 +7,18 @@ use crate::api::handlers;
 /// Handlers delegate to `sdl_wrapper`, which reuses the existing downloader and
 /// extractor modules so the HTTP API follows the CLI's hoster support.
 pub fn configure(config: &mut web::ServiceConfig) {
-    config.route("/health", web::get().to(handlers::health)).service(
-        web::scope("/api")
-            .route("/play", web::get().to(handlers::get_play))
-            .route("/play", web::post().to(handlers::post_play))
-            .route("/info", web::get().to(handlers::get_info))
-            .route("/info", web::post().to(handlers::post_info)),
-    );
+    config
+        .route("/health", web::get().to(handlers::health))
+        .route("/openapi.yaml", web::get().to(handlers::openapi_yaml))
+        .service(
+            web::scope("/api")
+                .route("/play", web::get().to(handlers::get_play))
+                .route("/play", web::post().to(handlers::post_play))
+                .route("/download", web::get().to(handlers::get_download))
+                .route("/download", web::post().to(handlers::post_download))
+                .route("/info", web::get().to(handlers::get_info))
+                .route("/info", web::post().to(handlers::post_info))
+                .route("/info_resolve", web::get().to(handlers::get_info_resolve))
+                .route("/info_resolve", web::post().to(handlers::post_info_resolve)),
+        );
 }

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -1,0 +1,17 @@
+use actix_web::web;
+
+use crate::api::handlers;
+
+/// Register SDL API routes.
+///
+/// Handlers delegate to `sdl_wrapper`, which reuses the existing downloader and
+/// extractor modules so the HTTP API follows the CLI's hoster support.
+pub fn configure(config: &mut web::ServiceConfig) {
+    config.route("/health", web::get().to(handlers::health)).service(
+        web::scope("/api")
+            .route("/play", web::get().to(handlers::get_play))
+            .route("/play", web::post().to(handlers::post_play))
+            .route("/info", web::get().to(handlers::get_info))
+            .route("/info", web::post().to(handlers::post_info)),
+    );
+}

--- a/src/api/sdl_wrapper.rs
+++ b/src/api/sdl_wrapper.rs
@@ -8,12 +8,12 @@ use actix_web::HttpResponse;
 use anyhow::Context;
 use bytes::Bytes;
 use futures_util::{StreamExt, TryStreamExt};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, OwnedSemaphorePermit};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use url::Url;
 
 use crate::api::error::ApiError;
-use crate::api::types::{InfoRequest, InfoResponse, PlayRequest};
+use crate::api::types::{ApiState, InfoRequest, InfoResponse, PlayRequest};
 use crate::downloaders::{
     self, AllOrSpecific, DownloadRequest, DownloadSettings, EpisodesRequest, ExtractorMatch, InstantiatedDownloader,
     Language, VideoType,
@@ -24,11 +24,12 @@ use once_cell::sync::Lazy;
 use std::sync::Mutex;
 
 const SCRAPE_TIMEOUT: Duration = Duration::from_secs(90);
-const HTTP_TIMEOUT: Duration = Duration::from_secs(30);
+const STREAM_PERMIT_TIMEOUT: Duration = Duration::from_secs(10);
 
 static API_LOG_WRAPPER: Lazy<Mutex<Option<SetLogWrapper>>> = Lazy::new(|| Mutex::new(None));
 
-pub async fn play(request: PlayRequest) -> Result<HttpResponse, ApiError> {
+pub async fn play(state: ApiState, request: PlayRequest) -> Result<HttpResponse, ApiError> {
+    let permit = acquire_stream_permit(&state).await?;
     let url = validate_url(&request.url)?;
     let extracted = if extractors::exists_extractor_for_url(url.as_str(), request.extractor.as_deref()).await {
         extract_direct_video(url.as_str(), &request).await?
@@ -40,7 +41,20 @@ pub async fn play(request: PlayRequest) -> Result<HttpResponse, ApiError> {
         ));
     };
 
-    stream_extracted_video(extracted.url, extracted.referer).await
+    stream_extracted_video(state.client.clone(), extracted.url, extracted.referer, permit).await
+}
+
+async fn acquire_stream_permit(state: &ApiState) -> Result<OwnedSemaphorePermit, ApiError> {
+    let timeout = std::env::var("SDL_API_STREAM_PERMIT_TIMEOUT_MS")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .map(Duration::from_millis)
+        .unwrap_or(STREAM_PERMIT_TIMEOUT);
+
+    tokio::time::timeout(timeout, state.download_semaphore.clone().acquire_owned())
+        .await
+        .map_err(|_| ApiError::ServiceUnavailable("too many concurrent streams".to_owned()))?
+        .map_err(|_| ApiError::ServiceUnavailable("stream limiter is closed".to_owned()))
 }
 
 async fn extract_direct_video(url: &str, request: &PlayRequest) -> Result<extractors::ExtractedVideo, ApiError> {
@@ -125,14 +139,15 @@ fn api_log_wrapper() -> Result<std::sync::MutexGuard<'static, Option<SetLogWrapp
     Ok(guard)
 }
 
-async fn stream_extracted_video(video_url: String, referer: Option<String>) -> Result<HttpResponse, ApiError> {
-    let client = reqwest::ClientBuilder::new()
-        .timeout(HTTP_TIMEOUT)
-        .build()
-        .map_err(anyhow::Error::from)?;
+async fn stream_extracted_video(
+    client: reqwest::Client,
+    video_url: String,
+    referer: Option<String>,
+    permit: OwnedSemaphorePermit,
+) -> Result<HttpResponse, ApiError> {
     let parsed = Url::parse(&video_url).context("extracted video url is invalid")?;
     if parsed.path().to_ascii_lowercase().ends_with(".m3u8") {
-        return Ok(stream_m3u8(client, parsed, referer).await?);
+        return Ok(stream_m3u8(client, parsed, referer, permit).await?);
     }
 
     let mut req = client.get(parsed.clone());
@@ -152,14 +167,17 @@ async fn stream_extracted_video(video_url: String, referer: Option<String>) -> R
         .unwrap_or("")
         .to_owned();
     if content_type.contains("mpegurl") || content_type.contains("application/vnd.apple.mpegurl") {
-        return Ok(stream_m3u8(client, parsed, referer).await?);
+        return Ok(stream_m3u8(client, parsed, referer, permit).await?);
     }
     let header_type = if parsed.path().to_ascii_lowercase().ends_with(".mp4") || content_type.contains("video/mp4") {
         "video/mp4"
     } else {
         "application/octet-stream"
     };
-    let stream = response.bytes_stream().map_err(actix_web::error::ErrorBadGateway);
+    let stream = response.bytes_stream().map(move |item| {
+        let _permit = &permit;
+        item.map_err(actix_web::error::ErrorBadGateway)
+    });
     Ok(base_stream_response(header_type).streaming(stream))
 }
 
@@ -167,6 +185,7 @@ async fn stream_m3u8(
     client: reqwest::Client,
     playlist_url: Url,
     referer: Option<String>,
+    permit: OwnedSemaphorePermit,
 ) -> Result<HttpResponse, ApiError> {
     let mut current_playlist_url = playlist_url;
     let segment_urls = loop {
@@ -204,6 +223,7 @@ async fn stream_m3u8(
         }
     };
     let stream = futures_util::stream::iter(segment_urls).then(move |segment_url| {
+        let _permit = &permit;
         let client = client.clone();
         let referer = referer.clone();
         async move {

--- a/src/api/sdl_wrapper.rs
+++ b/src/api/sdl_wrapper.rs
@@ -36,7 +36,7 @@ pub async fn play(state: ApiState, request: PlayRequest) -> Result<HttpResponse,
     } else if downloaders::exists_downloader_for_url(url.as_str()).await {
         extract_series_video(url.as_str(), request.clone()).await?
     } else {
-        return Err(ApiError::NotFound(
+        return Err(ApiError::UnsupportedUrl(
             "no downloader or extractor supports the supplied url".to_owned(),
         ));
     };
@@ -54,7 +54,7 @@ async fn acquire_stream_permit(state: &ApiState) -> Result<OwnedSemaphorePermit,
     tokio::time::timeout(timeout, state.download_semaphore.clone().acquire_owned())
         .await
         .map_err(|_| ApiError::ServiceUnavailable("too many concurrent streams".to_owned()))?
-        .map_err(|_| ApiError::ServiceUnavailable("stream limiter is closed".to_owned()))
+        .map_err(|_| ApiError::ServiceUnavailable("stream limiter is unavailable".to_owned()))
 }
 
 async fn extract_direct_video(url: &str, request: &PlayRequest) -> Result<extractors::ExtractedVideo, ApiError> {
@@ -71,11 +71,18 @@ async fn extract_direct_video(url: &str, request: &PlayRequest) -> Result<extrac
 
     match tokio::time::timeout(SCRAPE_TIMEOUT, extraction)
         .await
-        .map_err(|_| ApiError::BadRequest("video extraction timed out".to_owned()))?
+        .map_err(|_| ApiError::Timeout("video extraction timed out".to_owned()))?
     {
         Some(Ok(video)) => Ok(video),
-        Some(Err(err)) => Err(ApiError::Internal(err)),
-        None => Err(ApiError::NotFound("no extractor supports the supplied url".to_owned())),
+        Some(Err(err)) => {
+            log::warn!("Video extractor failed: {err:#}");
+            Err(ApiError::ExtractorFailed(
+                "failed to extract video from the supplied url".to_owned(),
+            ))
+        }
+        None => Err(ApiError::UnsupportedUrl(
+            "no extractor supports the supplied url".to_owned(),
+        )),
     }
 }
 
@@ -124,8 +131,11 @@ async fn extract_series_video(url: &str, request: PlayRequest) -> Result<extract
         result
     })
     .await
-    .map_err(|_| ApiError::BadRequest("series scraping timed out".to_owned()))?
-    .map_err(ApiError::Internal)
+    .map_err(|_| ApiError::Timeout("series scraping timed out".to_owned()))?
+    .map_err(|err| {
+        log::warn!("Series extractor failed: {err:#}");
+        ApiError::ExtractorFailed("failed to scrape a streamable episode from the supplied url".to_owned())
+    })
 }
 
 fn api_log_wrapper() -> Result<std::sync::MutexGuard<'static, Option<SetLogWrapper>>, anyhow::Error> {
@@ -145,7 +155,10 @@ async fn stream_extracted_video(
     referer: Option<String>,
     permit: OwnedSemaphorePermit,
 ) -> Result<HttpResponse, ApiError> {
-    let parsed = Url::parse(&video_url).context("extracted video url is invalid")?;
+    let parsed = Url::parse(&video_url).map_err(|err| {
+        log::warn!("Extractor returned an invalid video url: {err:#}");
+        ApiError::ExtractorFailed("extractor returned an invalid video url".to_owned())
+    })?;
     if parsed.path().to_ascii_lowercase().ends_with(".m3u8") {
         return Ok(stream_m3u8(client, parsed, referer, permit).await?);
     }
@@ -157,9 +170,9 @@ async fn stream_extracted_video(
     let response = req
         .send()
         .await
-        .map_err(anyhow::Error::from)?
+        .map_err(map_upstream_error)?
         .error_for_status()
-        .map_err(anyhow::Error::from)?;
+        .map_err(map_upstream_error)?;
     let content_type = response
         .headers()
         .get(reqwest::header::CONTENT_TYPE)
@@ -196,14 +209,16 @@ async fn stream_m3u8(
         let body = req
             .send()
             .await
-            .map_err(anyhow::Error::from)?
+            .map_err(map_upstream_error)?
             .error_for_status()
-            .map_err(anyhow::Error::from)?
+            .map_err(map_upstream_error)?
             .bytes()
             .await
-            .map_err(anyhow::Error::from)?;
-        let playlist =
-            m3u8_rs::parse_playlist_res(&body).map_err(|e| anyhow::anyhow!("failed to parse m3u8 playlist: {e:?}"))?;
+            .map_err(map_upstream_error)?;
+        let playlist = m3u8_rs::parse_playlist_res(&body).map_err(|err| {
+            log::warn!("Failed to parse upstream m3u8 playlist: {err:?}");
+            ApiError::UpstreamFailed("failed to parse upstream playlist".to_owned())
+        })?;
         match playlist {
             m3u8_rs::Playlist::MediaPlaylist(media) => {
                 break media
@@ -211,14 +226,20 @@ async fn stream_m3u8(
                     .into_iter()
                     .map(|s| current_playlist_url.join(&s.uri))
                     .collect::<Result<Vec<_>, _>>()
-                    .map_err(anyhow::Error::from)?;
+                    .map_err(|err| {
+                        log::warn!("Failed to resolve m3u8 segment url: {err:#}");
+                        ApiError::UpstreamFailed("failed to resolve upstream playlist segment".to_owned())
+                    })?;
             }
             m3u8_rs::Playlist::MasterPlaylist(master) => {
-                let variant = master
-                    .variants
-                    .first()
-                    .context("m3u8 master playlist has no variants")?;
-                current_playlist_url = current_playlist_url.join(&variant.uri).map_err(anyhow::Error::from)?;
+                let variant = master.variants.first().ok_or_else(|| {
+                    log::warn!("Upstream m3u8 master playlist has no variants");
+                    ApiError::UpstreamFailed("upstream playlist has no variants".to_owned())
+                })?;
+                current_playlist_url = current_playlist_url.join(&variant.uri).map_err(|err| {
+                    log::warn!("Failed to resolve m3u8 variant url: {err:#}");
+                    ApiError::UpstreamFailed("failed to resolve upstream playlist variant".to_owned())
+                })?;
             }
         }
     };
@@ -246,6 +267,15 @@ async fn stream_m3u8(
     Ok(base_stream_response("application/octet-stream").streaming(stream))
 }
 
+fn map_upstream_error(err: reqwest::Error) -> ApiError {
+    log::warn!("Upstream request failed: {err:#}");
+    if err.is_timeout() {
+        ApiError::Timeout("upstream request timed out".to_owned())
+    } else {
+        ApiError::UpstreamFailed("upstream request failed".to_owned())
+    }
+}
+
 fn base_stream_response(content_type: &'static str) -> actix_web::HttpResponseBuilder {
     let mut builder = HttpResponse::Ok();
     builder.insert_header((CONTENT_TYPE, content_type));
@@ -257,7 +287,7 @@ fn validate_url(raw: &str) -> Result<Url, ApiError> {
     if raw.trim().is_empty() {
         return Err(ApiError::BadRequest("url must not be empty".to_owned()));
     }
-    let url = Url::parse(raw).map_err(|err| ApiError::BadRequest(format!("invalid url: {err}")))?;
+    let url = Url::parse(raw).map_err(|_| ApiError::BadRequest("invalid url".to_owned()))?;
     match url.scheme() {
         "http" | "https" => Ok(url),
         _ => Err(ApiError::BadRequest("url must use http or https".to_owned())),
@@ -407,8 +437,11 @@ pub async fn info(request: InfoRequest) -> Result<InfoResponse, ApiError> {
             result
         })
         .await
-        .map_err(|_| ApiError::BadRequest("series info scraping timed out".to_owned()))?
-        .map_err(ApiError::Internal)?;
+        .map_err(|_| ApiError::Timeout("series info scraping timed out".to_owned()))?
+        .map_err(|err| {
+            log::warn!("Series info scraping failed: {err:#}");
+            ApiError::ExtractorFailed("failed to scrape series info from the supplied url".to_owned())
+        })?;
 
         return Ok(InfoResponse {
             supported: true,

--- a/src/api/sdl_wrapper.rs
+++ b/src/api/sdl_wrapper.rs
@@ -1,0 +1,56 @@
+//! Adapter functions between HTTP handlers and SDL internals.
+//!
+//! This module is the integration point for reusing the existing CLI logic:
+//! `downloaders::find_downloader_for_url` selects site downloaders,
+//! `InstantiatedDownloader::download` performs episode discovery/download task
+//! creation, `AniWorldSerienStream::get_series_info` provides series metadata,
+//! and `extractors::extract_video_url*` resolves supported hoster URLs. Keeping
+//! the API on these functions gives it the same hoster support as the CLI.
+
+use crate::api::error::ApiError;
+use crate::api::types::{InfoResponse, PlayRequest, PlayResponse};
+use crate::{downloaders, extractors};
+
+pub async fn play(request: PlayRequest) -> Result<PlayResponse, ApiError> {
+    if request.url.trim().is_empty() {
+        return Err(ApiError::BadRequest("url must not be empty".to_owned()));
+    }
+
+    let result = if let Some(extractor) = request.extractor.as_deref() {
+        extractors::extract_video_url_with_extractor_from_url(
+            &request.url,
+            extractor,
+            request.user_agent,
+            request.referer,
+        )
+        .await
+    } else {
+        extractors::extract_video_url(&request.url, request.user_agent, request.referer).await
+    };
+
+    match result {
+        Some(Ok(video)) => Ok(PlayResponse {
+            url: video.url,
+            referer: video.referer,
+        }),
+        Some(Err(err)) => Err(ApiError::Internal(err)),
+        None => Err(ApiError::NotFound("no extractor supports the supplied url".to_owned())),
+    }
+}
+
+pub async fn info(url: String) -> Result<InfoResponse, ApiError> {
+    if url.trim().is_empty() {
+        return Err(ApiError::BadRequest("url must not be empty".to_owned()));
+    }
+
+    let supported = downloaders::exists_downloader_for_url(&url).await;
+
+    Ok(InfoResponse {
+        supported,
+        downloader: supported.then_some("auto".to_owned()),
+        title: None,
+        description: None,
+        status: None,
+        year: None,
+    })
+}

--- a/src/api/sdl_wrapper.rs
+++ b/src/api/sdl_wrapper.rs
@@ -18,8 +18,8 @@ use crate::downloaders::{
     self, AllOrSpecific, DownloadRequest, DownloadSettings, EpisodesRequest, ExtractorMatch, InstantiatedDownloader,
     Language, VideoType,
 };
+use crate::extractors;
 use crate::logger::log_wrapper::{LogWrapper, SetLogWrapper};
-use crate::{chrome, dirs, download, extractors};
 use once_cell::sync::Lazy;
 use std::sync::Mutex;
 
@@ -34,7 +34,7 @@ pub async fn play(state: ApiState, request: PlayRequest) -> Result<HttpResponse,
     let extracted = if extractors::exists_extractor_for_url(url.as_str(), request.extractor.as_deref()).await {
         extract_direct_video(url.as_str(), &request).await?
     } else if downloaders::exists_downloader_for_url(url.as_str()).await {
-        extract_series_video(url.as_str(), request.clone()).await?
+        extract_series_video(state.clone(), url.as_str(), request.clone()).await?
     } else {
         return Err(ApiError::UnsupportedUrl(
             "no downloader or extractor supports the supplied url".to_owned(),
@@ -86,49 +86,41 @@ async fn extract_direct_video(url: &str, request: &PlayRequest) -> Result<extrac
     }
 }
 
-async fn extract_series_video(url: &str, request: PlayRequest) -> Result<extractors::ExtractedVideo, ApiError> {
+async fn extract_series_video(
+    state: ApiState,
+    url: &str,
+    request: PlayRequest,
+) -> Result<extractors::ExtractedVideo, ApiError> {
     let download_request = build_download_request(&request)?;
     reject_multi_episode_requests(&download_request.episodes)?;
+    let url = url.to_owned();
 
     tokio::time::timeout(SCRAPE_TIMEOUT, async move {
-        let data_dir = dirs::get_data_dir().await?;
-        let limiter = async_speed_limit::Limiter::new(f64::INFINITY);
-        let asset_downloader = {
-            let mut log_wrapper = api_log_wrapper()?;
-            download::Downloader::new(
-                log_wrapper.as_mut().expect("api log wrapper initialized"),
-                limiter,
-                false,
-                None,
-                None,
-                None,
-            )
-        };
-        let (driver, mut child) = chrome::ChromeDriver::get(&data_dir, &asset_downloader, true).await?;
-        let result = async {
-            let downloader = downloaders::find_downloader_for_url(&driver, false, url)
-                .await
-                .context("no downloader supports the supplied url")?;
-            let (tx, rx) = mpsc::unbounded_channel();
-            let settings = DownloadSettings::new(None, || Duration::ZERO);
-            let download_future = downloader.download(download_request, settings, tx);
-            tokio::pin!(download_future);
-            let mut rx = UnboundedReceiverStream::new(rx);
-            tokio::select! {
-                task = rx.next() => {
-                    let task = task.context("downloader did not produce a streamable episode")?;
-                    Ok(extractors::ExtractedVideo { url: task.download_url, referer: task.referer })
-                }
-                result = &mut download_future => {
-                    result?;
-                    anyhow::bail!("downloader completed without producing a streamable episode")
-                }
-            }
-        }
-        .await;
-        let _ = driver.quit().await;
-        let _ = child.kill();
-        result
+        state
+            .browser
+            .with_driver(|driver| {
+                Box::pin(async move {
+                    let downloader = downloaders::find_downloader_for_url(driver, false, &url)
+                        .await
+                        .context("no downloader supports the supplied url")?;
+                    let (tx, rx) = mpsc::unbounded_channel();
+                    let settings = DownloadSettings::new(None, || Duration::ZERO);
+                    let download_future = downloader.download(download_request, settings, tx);
+                    tokio::pin!(download_future);
+                    let mut rx = UnboundedReceiverStream::new(rx);
+                    tokio::select! {
+                        task = rx.next() => {
+                            let task = task.context("downloader did not produce a streamable episode")?;
+                            Ok(extractors::ExtractedVideo { url: task.download_url, referer: task.referer })
+                        }
+                        result = &mut download_future => {
+                            result?;
+                            anyhow::bail!("downloader completed without producing a streamable episode")
+                        }
+                    }
+                })
+            })
+            .await
     })
     .await
     .map_err(|_| ApiError::Timeout("series scraping timed out".to_owned()))?
@@ -138,7 +130,7 @@ async fn extract_series_video(url: &str, request: PlayRequest) -> Result<extract
     })
 }
 
-fn api_log_wrapper() -> Result<std::sync::MutexGuard<'static, Option<SetLogWrapper>>, anyhow::Error> {
+pub(crate) fn api_log_wrapper() -> Result<std::sync::MutexGuard<'static, Option<SetLogWrapper>>, anyhow::Error> {
     let mut guard = API_LOG_WRAPPER
         .lock()
         .map_err(|_| anyhow::anyhow!("api logger lock poisoned"))?;
@@ -403,38 +395,25 @@ fn reject_multi_episode_requests(episodes: &EpisodesRequest) -> Result<(), ApiEr
     }
 }
 
-pub async fn info(request: InfoRequest) -> Result<InfoResponse, ApiError> {
+pub async fn info(state: ApiState, request: InfoRequest) -> Result<InfoResponse, ApiError> {
     let url = validate_url(&request.url)?;
     if downloaders::exists_downloader_for_url(url.as_str()).await {
         let catalog = tokio::time::timeout(SCRAPE_TIMEOUT, async {
-            let data_dir = dirs::get_data_dir().await?;
-            let limiter = async_speed_limit::Limiter::new(f64::INFINITY);
-            let asset_downloader = {
-                let mut log_wrapper = api_log_wrapper()?;
-                download::Downloader::new(
-                    log_wrapper.as_mut().expect("api log wrapper initialized"),
-                    limiter,
-                    false,
-                    None,
-                    None,
-                    None,
-                )
-            };
-            let (driver, mut child) = chrome::ChromeDriver::get(&data_dir, &asset_downloader, true).await?;
-            let result = async {
-                let downloader = downloaders::find_downloader_for_url(&driver, false, url.as_str())
-                    .await
-                    .context("no downloader supports the supplied url")?;
-                downloader
-                    .get_catalog_info(downloaders::InfoRequest {
-                        resolve_streams: request.resolve_streams,
+            state
+                .browser
+                .with_driver(|driver| {
+                    Box::pin(async move {
+                        let downloader = downloaders::find_downloader_for_url(driver, false, url.as_str())
+                            .await
+                            .context("no downloader supports the supplied url")?;
+                        downloader
+                            .get_catalog_info(downloaders::InfoRequest {
+                                resolve_streams: request.resolve_streams,
+                            })
+                            .await
                     })
-                    .await
-            }
-            .await;
-            let _ = driver.quit().await;
-            let _ = child.kill();
-            result
+                })
+                .await
         })
         .await
         .map_err(|_| ApiError::Timeout("series info scraping timed out".to_owned()))?

--- a/src/api/sdl_wrapper.rs
+++ b/src/api/sdl_wrapper.rs
@@ -13,7 +13,7 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 use url::Url;
 
 use crate::api::error::ApiError;
-use crate::api::types::{InfoResponse, PlayRequest};
+use crate::api::types::{InfoRequest, InfoResponse, PlayRequest};
 use crate::downloaders::{
     self, AllOrSpecific, DownloadRequest, DownloadSettings, EpisodesRequest, ExtractorMatch, InstantiatedDownloader,
     Language, VideoType,
@@ -353,16 +353,62 @@ fn reject_multi_episode_requests(episodes: &EpisodesRequest) -> Result<(), ApiEr
     }
 }
 
-pub async fn info(url: String) -> Result<InfoResponse, ApiError> {
-    let url = validate_url(&url)?;
-    let supported = downloaders::exists_downloader_for_url(url.as_str()).await
-        || extractors::exists_extractor_for_url(url.as_str(), None).await;
+pub async fn info(request: InfoRequest) -> Result<InfoResponse, ApiError> {
+    let url = validate_url(&request.url)?;
+    if downloaders::exists_downloader_for_url(url.as_str()).await {
+        let catalog = tokio::time::timeout(SCRAPE_TIMEOUT, async {
+            let data_dir = dirs::get_data_dir().await?;
+            let limiter = async_speed_limit::Limiter::new(f64::INFINITY);
+            let asset_downloader = {
+                let mut log_wrapper = api_log_wrapper()?;
+                download::Downloader::new(
+                    log_wrapper.as_mut().expect("api log wrapper initialized"),
+                    limiter,
+                    false,
+                    None,
+                    None,
+                    None,
+                )
+            };
+            let (driver, mut child) = chrome::ChromeDriver::get(&data_dir, &asset_downloader, true).await?;
+            let result = async {
+                let downloader = downloaders::find_downloader_for_url(&driver, false, url.as_str())
+                    .await
+                    .context("no downloader supports the supplied url")?;
+                downloader
+                    .get_catalog_info(downloaders::InfoRequest {
+                        resolve_streams: request.resolve_streams,
+                    })
+                    .await
+            }
+            .await;
+            let _ = driver.quit().await;
+            let _ = child.kill();
+            result
+        })
+        .await
+        .map_err(|_| ApiError::BadRequest("series info scraping timed out".to_owned()))?
+        .map_err(ApiError::Internal)?;
+
+        return Ok(InfoResponse {
+            supported: true,
+            downloader: Some("auto".to_owned()),
+            title: Some(catalog.title.clone()),
+            description: catalog.description.clone(),
+            status: catalog.status.clone(),
+            year: catalog.year,
+            catalog: Some(catalog),
+        });
+    }
+
+    let supported = extractors::exists_extractor_for_url(url.as_str(), None).await;
     Ok(InfoResponse {
         supported,
-        downloader: supported.then_some("auto".to_owned()),
+        downloader: supported.then_some("extractor".to_owned()),
         title: None,
         description: None,
         status: None,
         year: None,
+        catalog: None,
     })
 }

--- a/src/api/sdl_wrapper.rs
+++ b/src/api/sdl_wrapper.rs
@@ -1,50 +1,362 @@
 //! Adapter functions between HTTP handlers and SDL internals.
-//!
-//! This module is the integration point for reusing the existing CLI logic:
-//! `downloaders::find_downloader_for_url` selects site downloaders,
-//! `InstantiatedDownloader::download` performs episode discovery/download task
-//! creation, `AniWorldSerienStream::get_series_info` provides series metadata,
-//! and `extractors::extract_video_url*` resolves supported hoster URLs. Keeping
-//! the API on these functions gives it the same hoster support as the CLI.
+
+use std::ops::RangeInclusive;
+use std::time::Duration;
+
+use actix_web::http::header::{CONTENT_DISPOSITION, CONTENT_TYPE, REFERER};
+use actix_web::HttpResponse;
+use anyhow::Context;
+use bytes::Bytes;
+use futures_util::{StreamExt, TryStreamExt};
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::UnboundedReceiverStream;
+use url::Url;
 
 use crate::api::error::ApiError;
-use crate::api::types::{InfoResponse, PlayRequest, PlayResponse};
-use crate::{downloaders, extractors};
+use crate::api::types::{InfoResponse, PlayRequest};
+use crate::downloaders::{
+    self, AllOrSpecific, DownloadRequest, DownloadSettings, EpisodesRequest, ExtractorMatch, InstantiatedDownloader,
+    Language, VideoType,
+};
+use crate::logger::log_wrapper::{LogWrapper, SetLogWrapper};
+use crate::{chrome, dirs, download, extractors};
+use once_cell::sync::Lazy;
+use std::sync::Mutex;
 
-pub async fn play(request: PlayRequest) -> Result<PlayResponse, ApiError> {
-    if request.url.trim().is_empty() {
-        return Err(ApiError::BadRequest("url must not be empty".to_owned()));
-    }
+const SCRAPE_TIMEOUT: Duration = Duration::from_secs(90);
+const HTTP_TIMEOUT: Duration = Duration::from_secs(30);
 
-    let result = if let Some(extractor) = request.extractor.as_deref() {
-        extractors::extract_video_url_with_extractor_from_url(
-            &request.url,
-            extractor,
-            request.user_agent,
-            request.referer,
-        )
-        .await
+static API_LOG_WRAPPER: Lazy<Mutex<Option<SetLogWrapper>>> = Lazy::new(|| Mutex::new(None));
+
+pub async fn play(request: PlayRequest) -> Result<HttpResponse, ApiError> {
+    let url = validate_url(&request.url)?;
+    let extracted = if extractors::exists_extractor_for_url(url.as_str(), request.extractor.as_deref()).await {
+        extract_direct_video(url.as_str(), &request).await?
+    } else if downloaders::exists_downloader_for_url(url.as_str()).await {
+        extract_series_video(url.as_str(), request.clone()).await?
     } else {
-        extractors::extract_video_url(&request.url, request.user_agent, request.referer).await
+        return Err(ApiError::NotFound(
+            "no downloader or extractor supports the supplied url".to_owned(),
+        ));
     };
 
-    match result {
-        Some(Ok(video)) => Ok(PlayResponse {
-            url: video.url,
-            referer: video.referer,
-        }),
+    stream_extracted_video(extracted.url, extracted.referer).await
+}
+
+async fn extract_direct_video(url: &str, request: &PlayRequest) -> Result<extractors::ExtractedVideo, ApiError> {
+    let user_agent = request.user_agent.clone();
+    let referer = request.referer.clone();
+    let extraction = async {
+        let extractor = request.extractor.clone().or_else(|| first_named_extractor(request));
+        if let Some(extractor) = extractor.as_deref() {
+            extractors::extract_video_url_with_extractor_from_url(url, extractor, user_agent, referer).await
+        } else {
+            extractors::extract_video_url(url, user_agent, referer).await
+        }
+    };
+
+    match tokio::time::timeout(SCRAPE_TIMEOUT, extraction)
+        .await
+        .map_err(|_| ApiError::BadRequest("video extraction timed out".to_owned()))?
+    {
+        Some(Ok(video)) => Ok(video),
         Some(Err(err)) => Err(ApiError::Internal(err)),
         None => Err(ApiError::NotFound("no extractor supports the supplied url".to_owned())),
     }
 }
 
-pub async fn info(url: String) -> Result<InfoResponse, ApiError> {
-    if url.trim().is_empty() {
-        return Err(ApiError::BadRequest("url must not be empty".to_owned()));
+async fn extract_series_video(url: &str, request: PlayRequest) -> Result<extractors::ExtractedVideo, ApiError> {
+    let download_request = build_download_request(&request)?;
+    reject_multi_episode_requests(&download_request.episodes)?;
+
+    tokio::time::timeout(SCRAPE_TIMEOUT, async move {
+        let data_dir = dirs::get_data_dir().await?;
+        let limiter = async_speed_limit::Limiter::new(f64::INFINITY);
+        let asset_downloader = {
+            let mut log_wrapper = api_log_wrapper()?;
+            download::Downloader::new(
+                log_wrapper.as_mut().expect("api log wrapper initialized"),
+                limiter,
+                false,
+                None,
+                None,
+                None,
+            )
+        };
+        let (driver, mut child) = chrome::ChromeDriver::get(&data_dir, &asset_downloader, true).await?;
+        let result = async {
+            let downloader = downloaders::find_downloader_for_url(&driver, false, url)
+                .await
+                .context("no downloader supports the supplied url")?;
+            let (tx, rx) = mpsc::unbounded_channel();
+            let settings = DownloadSettings::new(None, || Duration::ZERO);
+            let download_future = downloader.download(download_request, settings, tx);
+            tokio::pin!(download_future);
+            let mut rx = UnboundedReceiverStream::new(rx);
+            tokio::select! {
+                task = rx.next() => {
+                    let task = task.context("downloader did not produce a streamable episode")?;
+                    Ok(extractors::ExtractedVideo { url: task.download_url, referer: task.referer })
+                }
+                result = &mut download_future => {
+                    result?;
+                    anyhow::bail!("downloader completed without producing a streamable episode")
+                }
+            }
+        }
+        .await;
+        let _ = driver.quit().await;
+        let _ = child.kill();
+        result
+    })
+    .await
+    .map_err(|_| ApiError::BadRequest("series scraping timed out".to_owned()))?
+    .map_err(ApiError::Internal)
+}
+
+fn api_log_wrapper() -> Result<std::sync::MutexGuard<'static, Option<SetLogWrapper>>, anyhow::Error> {
+    let mut guard = API_LOG_WRAPPER
+        .lock()
+        .map_err(|_| anyhow::anyhow!("api logger lock poisoned"))?;
+    if guard.is_none() {
+        let logger = crate::logger::default_logger(false);
+        *guard = Some(LogWrapper::new(None, logger).try_init()?);
+    }
+    Ok(guard)
+}
+
+async fn stream_extracted_video(video_url: String, referer: Option<String>) -> Result<HttpResponse, ApiError> {
+    let client = reqwest::ClientBuilder::new()
+        .timeout(HTTP_TIMEOUT)
+        .build()
+        .map_err(anyhow::Error::from)?;
+    let parsed = Url::parse(&video_url).context("extracted video url is invalid")?;
+    if parsed.path().to_ascii_lowercase().ends_with(".m3u8") {
+        return Ok(stream_m3u8(client, parsed, referer).await?);
     }
 
-    let supported = downloaders::exists_downloader_for_url(&url).await;
+    let mut req = client.get(parsed.clone());
+    if let Some(referer) = referer.as_deref() {
+        req = req.header(REFERER.as_str(), referer);
+    }
+    let response = req
+        .send()
+        .await
+        .map_err(anyhow::Error::from)?
+        .error_for_status()
+        .map_err(anyhow::Error::from)?;
+    let content_type = response
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .to_owned();
+    if content_type.contains("mpegurl") || content_type.contains("application/vnd.apple.mpegurl") {
+        return Ok(stream_m3u8(client, parsed, referer).await?);
+    }
+    let header_type = if parsed.path().to_ascii_lowercase().ends_with(".mp4") || content_type.contains("video/mp4") {
+        "video/mp4"
+    } else {
+        "application/octet-stream"
+    };
+    let stream = response.bytes_stream().map_err(actix_web::error::ErrorBadGateway);
+    Ok(base_stream_response(header_type).streaming(stream))
+}
 
+async fn stream_m3u8(
+    client: reqwest::Client,
+    playlist_url: Url,
+    referer: Option<String>,
+) -> Result<HttpResponse, ApiError> {
+    let mut current_playlist_url = playlist_url;
+    let segment_urls = loop {
+        let mut req = client.get(current_playlist_url.clone());
+        if let Some(referer) = referer.as_deref() {
+            req = req.header(REFERER.as_str(), referer);
+        }
+        let body = req
+            .send()
+            .await
+            .map_err(anyhow::Error::from)?
+            .error_for_status()
+            .map_err(anyhow::Error::from)?
+            .bytes()
+            .await
+            .map_err(anyhow::Error::from)?;
+        let playlist =
+            m3u8_rs::parse_playlist_res(&body).map_err(|e| anyhow::anyhow!("failed to parse m3u8 playlist: {e:?}"))?;
+        match playlist {
+            m3u8_rs::Playlist::MediaPlaylist(media) => {
+                break media
+                    .segments
+                    .into_iter()
+                    .map(|s| current_playlist_url.join(&s.uri))
+                    .collect::<Result<Vec<_>, _>>()
+                    .map_err(anyhow::Error::from)?;
+            }
+            m3u8_rs::Playlist::MasterPlaylist(master) => {
+                let variant = master
+                    .variants
+                    .first()
+                    .context("m3u8 master playlist has no variants")?;
+                current_playlist_url = current_playlist_url.join(&variant.uri).map_err(anyhow::Error::from)?;
+            }
+        }
+    };
+    let stream = futures_util::stream::iter(segment_urls).then(move |segment_url| {
+        let client = client.clone();
+        let referer = referer.clone();
+        async move {
+            let mut req = client.get(segment_url);
+            if let Some(referer) = referer.as_deref() {
+                req = req.header(REFERER.as_str(), referer);
+            }
+            let bytes = req
+                .send()
+                .await
+                .map_err(actix_web::error::ErrorBadGateway)?
+                .error_for_status()
+                .map_err(actix_web::error::ErrorBadGateway)?
+                .bytes()
+                .await
+                .map_err(actix_web::error::ErrorBadGateway)?;
+            Ok::<Bytes, actix_web::Error>(bytes)
+        }
+    });
+    Ok(base_stream_response("application/octet-stream").streaming(stream))
+}
+
+fn base_stream_response(content_type: &'static str) -> actix_web::HttpResponseBuilder {
+    let mut builder = HttpResponse::Ok();
+    builder.insert_header((CONTENT_TYPE, content_type));
+    builder.insert_header((CONTENT_DISPOSITION, "inline; filename=\"sdl-stream\""));
+    builder
+}
+
+fn validate_url(raw: &str) -> Result<Url, ApiError> {
+    if raw.trim().is_empty() {
+        return Err(ApiError::BadRequest("url must not be empty".to_owned()));
+    }
+    let url = Url::parse(raw).map_err(|err| ApiError::BadRequest(format!("invalid url: {err}")))?;
+    match url.scheme() {
+        "http" | "https" => Ok(url),
+        _ => Err(ApiError::BadRequest("url must use http or https".to_owned())),
+    }
+}
+
+fn build_download_request(request: &PlayRequest) -> Result<DownloadRequest, ApiError> {
+    Ok(DownloadRequest {
+        language: parse_video_type(request)?,
+        episodes: parse_episodes(&request.episodes, &request.seasons)?,
+        extractor_priorities: parse_extractor_priorities(request)?,
+    })
+}
+
+fn parse_video_type(request: &PlayRequest) -> Result<VideoType, ApiError> {
+    let language = match request
+        .language
+        .as_deref()
+        .unwrap_or("unspecified")
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "unspecified" | "any" => Language::Unspecified,
+        value => Language::try_from(value).map_err(|err| ApiError::BadRequest(err.to_string()))?,
+    };
+    match request
+        .video_type
+        .as_deref()
+        .unwrap_or("unspecified")
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "unspecified" | "any" => Ok(VideoType::Unspecified(language)),
+        "raw" => Ok(VideoType::Raw),
+        "dub" => Ok(VideoType::Dub(language)),
+        "sub" => Ok(VideoType::Sub(language)),
+        other => Err(ApiError::BadRequest(format!("unknown video_type: {other}"))),
+    }
+}
+
+fn parse_episodes(episodes: &Option<String>, seasons: &Option<String>) -> Result<EpisodesRequest, ApiError> {
+    match (episodes.as_deref(), seasons.as_deref()) {
+        (None, None) => Ok(EpisodesRequest::Unspecified),
+        (Some(_), Some(_)) => Err(ApiError::BadRequest(
+            "episodes and seasons are mutually exclusive".to_owned(),
+        )),
+        (Some(value), None) => Ok(EpisodesRequest::Episodes(parse_all_or_specific(value)?)),
+        (None, Some(value)) => Ok(EpisodesRequest::Seasons(parse_all_or_specific(value)?)),
+    }
+}
+
+fn parse_all_or_specific(value: &str) -> Result<AllOrSpecific, ApiError> {
+    if value.eq_ignore_ascii_case("all") {
+        return Ok(AllOrSpecific::All);
+    }
+    let ranges = value
+        .split(',')
+        .map(|part| {
+            let (start, end) = part.split_once('-').unwrap_or((part, part));
+            let start: u32 = start
+                .trim()
+                .parse()
+                .map_err(|_| ApiError::BadRequest(format!("invalid range: {part}")))?;
+            let end: u32 = end
+                .trim()
+                .parse()
+                .map_err(|_| ApiError::BadRequest(format!("invalid range: {part}")))?;
+            Ok(start..=end)
+        })
+        .collect::<Result<Vec<RangeInclusive<u32>>, ApiError>>()?;
+    Ok(AllOrSpecific::Specific(ranges))
+}
+
+fn parse_extractor_priorities(request: &PlayRequest) -> Result<Vec<ExtractorMatch>, ApiError> {
+    let names = request.extractor_priorities.clone().unwrap_or_default();
+    names
+        .into_iter()
+        .map(|name| {
+            if name == "*" || name.eq_ignore_ascii_case("any") {
+                Ok(ExtractorMatch::Any)
+            } else if extractors::exists_extractor_with_name(&name) {
+                Ok(ExtractorMatch::Name(name))
+            } else {
+                Err(ApiError::BadRequest(format!("no extractor with name: {name}")))
+            }
+        })
+        .collect()
+}
+
+fn first_named_extractor(request: &PlayRequest) -> Option<String> {
+    request
+        .extractor_priorities
+        .as_ref()?
+        .iter()
+        .find(|name| *name != "*" && !name.eq_ignore_ascii_case("any"))
+        .cloned()
+}
+
+fn reject_multi_episode_requests(episodes: &EpisodesRequest) -> Result<(), ApiError> {
+    match episodes {
+        EpisodesRequest::Seasons(AllOrSpecific::All) | EpisodesRequest::Episodes(AllOrSpecific::All) => Err(
+            ApiError::BadRequest("/api/play streams a single episode; request one episode instead of all".to_owned()),
+        ),
+        EpisodesRequest::Seasons(AllOrSpecific::Specific(ranges))
+        | EpisodesRequest::Episodes(AllOrSpecific::Specific(ranges))
+            if ranges.len() > 1 || ranges.iter().any(|range| range.start() != range.end()) =>
+        {
+            Err(ApiError::BadRequest(
+                "/api/play streams a single episode; multiple episodes are not supported".to_owned(),
+            ))
+        }
+        _ => Ok(()),
+    }
+}
+
+pub async fn info(url: String) -> Result<InfoResponse, ApiError> {
+    let url = validate_url(&url)?;
+    let supported = downloaders::exists_downloader_for_url(url.as_str()).await
+        || extractors::exists_extractor_for_url(url.as_str(), None).await;
     Ok(InfoResponse {
         supported,
         downloader: supported.then_some("auto".to_owned()),

--- a/src/api/sdl_wrapper.rs
+++ b/src/api/sdl_wrapper.rs
@@ -13,7 +13,7 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 use url::Url;
 
 use crate::api::error::ApiError;
-use crate::api::types::{ApiState, InfoRequest, InfoResponse, PlayRequest};
+use crate::api::types::{ApiState, InfoRequest, InfoResolveRequest, InfoResolveResponse, InfoResponse, PlayRequest};
 use crate::downloaders::{
     self, AllOrSpecific, DownloadRequest, DownloadSettings, EpisodesRequest, ExtractorMatch, InstantiatedDownloader,
     Language, VideoType,
@@ -31,17 +31,39 @@ static API_LOG_WRAPPER: Lazy<Mutex<Option<SetLogWrapper>>> = Lazy::new(|| Mutex:
 pub async fn play(state: ApiState, request: PlayRequest) -> Result<HttpResponse, ApiError> {
     let permit = acquire_stream_permit(&state).await?;
     let url = validate_url(&request.url)?;
-    let extracted = if extractors::exists_extractor_for_url(url.as_str(), request.extractor.as_deref()).await {
-        extract_direct_video(url.as_str(), &request).await?
-    } else if downloaders::exists_downloader_for_url(url.as_str()).await {
-        extract_series_video(state.clone(), url.as_str(), request.clone()).await?
-    } else {
-        return Err(ApiError::UnsupportedUrl(
-            "no downloader or extractor supports the supplied url".to_owned(),
-        ));
-    };
+    let extracted = resolve_playable_video(state.clone(), url.as_str(), request).await?;
+    stream_extracted_video(state.client.clone(), extracted.url, extracted.referer, permit, false).await
+}
 
-    stream_extracted_video(state.client.clone(), extracted.url, extracted.referer, permit).await
+pub async fn download(state: ApiState, request: PlayRequest) -> Result<HttpResponse, ApiError> {
+    let permit = acquire_stream_permit(&state).await?;
+    let url = validate_url(&request.url)?;
+    let extracted = resolve_playable_video(state.clone(), url.as_str(), request).await?;
+    stream_extracted_video(state.client.clone(), extracted.url, extracted.referer, permit, true).await
+}
+
+async fn resolve_playable_video(
+    state: ApiState,
+    url: &str,
+    request: PlayRequest,
+) -> Result<extractors::ExtractedVideo, ApiError> {
+    if extractors::exists_extractor_for_url(url, request.extractor.as_deref()).await {
+        extract_direct_video(url, &request).await
+    } else if downloaders::exists_downloader_for_url(url).await {
+        extract_series_video(state, url, request).await
+    } else if let Some(resolved_url) = resolve_generic_link(&state.client, url).await? {
+        if extractors::exists_extractor_for_url(resolved_url.as_str(), request.extractor.as_deref()).await {
+            extract_direct_video(resolved_url.as_str(), &request).await
+        } else {
+            Err(ApiError::UnsupportedUrl(
+                "generic link did not resolve to a supported extractor url".to_owned(),
+            ))
+        }
+    } else {
+        Err(ApiError::UnsupportedUrl(
+            "no downloader or extractor supports the supplied url".to_owned(),
+        ))
+    }
 }
 
 async fn acquire_stream_permit(state: &ApiState) -> Result<OwnedSemaphorePermit, ApiError> {
@@ -146,13 +168,14 @@ async fn stream_extracted_video(
     video_url: String,
     referer: Option<String>,
     permit: OwnedSemaphorePermit,
+    download: bool,
 ) -> Result<HttpResponse, ApiError> {
     let parsed = Url::parse(&video_url).map_err(|err| {
         log::warn!("Extractor returned an invalid video url: {err:#}");
         ApiError::ExtractorFailed("extractor returned an invalid video url".to_owned())
     })?;
     if parsed.path().to_ascii_lowercase().ends_with(".m3u8") {
-        return Ok(stream_m3u8(client, parsed, referer, permit).await?);
+        return Ok(stream_m3u8(client, parsed, referer, permit, download).await?);
     }
 
     let mut req = client.get(parsed.clone());
@@ -172,7 +195,7 @@ async fn stream_extracted_video(
         .unwrap_or("")
         .to_owned();
     if content_type.contains("mpegurl") || content_type.contains("application/vnd.apple.mpegurl") {
-        return Ok(stream_m3u8(client, parsed, referer, permit).await?);
+        return Ok(stream_m3u8(client, parsed, referer, permit, download).await?);
     }
     let header_type = if parsed.path().to_ascii_lowercase().ends_with(".mp4") || content_type.contains("video/mp4") {
         "video/mp4"
@@ -183,7 +206,7 @@ async fn stream_extracted_video(
         let _permit = &permit;
         item.map_err(actix_web::error::ErrorBadGateway)
     });
-    Ok(base_stream_response(header_type).streaming(stream))
+    Ok(base_stream_response(header_type, download).streaming(stream))
 }
 
 async fn stream_m3u8(
@@ -191,6 +214,7 @@ async fn stream_m3u8(
     playlist_url: Url,
     referer: Option<String>,
     permit: OwnedSemaphorePermit,
+    download: bool,
 ) -> Result<HttpResponse, ApiError> {
     let mut current_playlist_url = playlist_url;
     let segment_urls = loop {
@@ -256,7 +280,7 @@ async fn stream_m3u8(
             Ok::<Bytes, actix_web::Error>(bytes)
         }
     });
-    Ok(base_stream_response("application/octet-stream").streaming(stream))
+    Ok(base_stream_response("application/octet-stream", download).streaming(stream))
 }
 
 fn map_upstream_error(err: reqwest::Error) -> ApiError {
@@ -268,10 +292,15 @@ fn map_upstream_error(err: reqwest::Error) -> ApiError {
     }
 }
 
-fn base_stream_response(content_type: &'static str) -> actix_web::HttpResponseBuilder {
+fn base_stream_response(content_type: &'static str, download: bool) -> actix_web::HttpResponseBuilder {
     let mut builder = HttpResponse::Ok();
     builder.insert_header((CONTENT_TYPE, content_type));
-    builder.insert_header((CONTENT_DISPOSITION, "inline; filename=\"sdl-stream\""));
+    let disposition = if download {
+        "attachment; filename=\"sdl-download\""
+    } else {
+        "inline; filename=\"sdl-stream\""
+    };
+    builder.insert_header((CONTENT_DISPOSITION, disposition));
     builder
 }
 
@@ -392,6 +421,67 @@ fn reject_multi_episode_requests(episodes: &EpisodesRequest) -> Result<(), ApiEr
             ))
         }
         _ => Ok(()),
+    }
+}
+
+async fn resolve_generic_link(client: &reqwest::Client, url: &str) -> Result<Option<String>, ApiError> {
+    let parsed = Url::parse(url).map_err(|_| ApiError::BadRequest("invalid url".to_owned()))?;
+    let Some(host) = parsed.host_str().map(|host| host.to_ascii_lowercase()) else {
+        return Ok(None);
+    };
+    let is_generic = matches!(
+        host.as_str(),
+        "s.to" | "sx.to" | "aniworld.to" | "www.s.to" | "www.sx.to" | "www.aniworld.to"
+    ) && (parsed.path().starts_with("/r") || parsed.path().starts_with("/redirect"));
+    if !is_generic {
+        return Ok(None);
+    }
+    let response = client.get(parsed).send().await.map_err(map_upstream_error)?;
+    Ok(Some(response.url().as_str().to_owned()))
+}
+
+pub async fn info_resolve(state: ApiState, request: InfoResolveRequest) -> Result<InfoResolveResponse, ApiError> {
+    let input_url = validate_url(&request.url)?.to_string();
+    let page_url = resolve_generic_link(&state.client, &input_url)
+        .await?
+        .unwrap_or_else(|| input_url.clone());
+    let extraction = if extractors::exists_extractor_for_url(&page_url, request.extractor.as_deref()).await {
+        let play_request = PlayRequest {
+            url: page_url.clone(),
+            language: None,
+            video_type: None,
+            episodes: None,
+            seasons: None,
+            extractor_priorities: None,
+            extractor: request.extractor.clone(),
+            user_agent: request.user_agent.clone(),
+            referer: request.referer.clone().or_else(|| Some(input_url.clone())),
+        };
+        extract_direct_video(&page_url, &play_request).await
+    } else {
+        Err(ApiError::UnsupportedUrl(
+            "resolved url is not supported by any extractor".to_owned(),
+        ))
+    };
+    match extraction {
+        Ok(video) => Ok(InfoResolveResponse {
+            supported: true,
+            input_url,
+            resolved_page_url: Some(page_url),
+            video_url: Some(video.url),
+            referer: video.referer,
+            extractor: request.extractor,
+            error: None,
+        }),
+        Err(err) => Ok(InfoResolveResponse {
+            supported: false,
+            input_url,
+            resolved_page_url: Some(page_url),
+            video_url: None,
+            referer: None,
+            extractor: request.extractor,
+            error: Some(err.to_string()),
+        }),
     }
 }
 

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -1,3 +1,4 @@
+use crate::downloaders::SeriesCatalogInfo;
 use serde::{Deserialize, Serialize};
 
 /// Request payload/query for `/api/play`.
@@ -36,6 +37,8 @@ pub struct PlayResponse {
 #[derive(Debug, Clone, Deserialize)]
 pub struct InfoRequest {
     pub url: String,
+    #[serde(default)]
+    pub resolve_streams: bool,
 }
 
 /// Response payload for `/api/info`.
@@ -47,6 +50,7 @@ pub struct InfoResponse {
     pub description: Option<String>,
     pub status: Option<String>,
     pub year: Option<u32>,
+    pub catalog: Option<SeriesCatalogInfo>,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -29,6 +29,11 @@ pub struct PlayRequest {
 pub type PlayQuery = PlayRequest;
 pub type PlayJson = PlayRequest;
 
+/// Request payload/query for `/api/download`.
+pub type DownloadRequest = PlayRequest;
+pub type DownloadQuery = DownloadRequest;
+pub type DownloadJson = DownloadRequest;
+
 /// Shared state for API handlers.
 #[derive(Debug, Clone)]
 pub struct ApiState {
@@ -50,6 +55,29 @@ pub struct InfoRequest {
     pub url: String,
     #[serde(default)]
     pub resolve_streams: bool,
+}
+
+/// Request payload/query for `/api/info_resolve`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct InfoResolveRequest {
+    pub url: String,
+    #[serde(default)]
+    pub extractor: Option<String>,
+    #[serde(default)]
+    pub user_agent: Option<String>,
+    #[serde(default)]
+    pub referer: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct InfoResolveResponse {
+    pub supported: bool,
+    pub input_url: String,
+    pub resolved_page_url: Option<String>,
+    pub video_url: Option<String>,
+    pub referer: Option<String>,
+    pub extractor: Option<String>,
+    pub error: Option<String>,
 }
 
 /// Response payload for `/api/info`.

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::downloaders::SeriesCatalogInfo;
 use serde::{Deserialize, Serialize};
 
@@ -25,6 +27,13 @@ pub struct PlayRequest {
 
 pub type PlayQuery = PlayRequest;
 pub type PlayJson = PlayRequest;
+
+/// Shared state for API handlers.
+#[derive(Debug, Clone)]
+pub struct ApiState {
+    pub download_semaphore: Arc<tokio::sync::Semaphore>,
+    pub client: reqwest::Client,
+}
 
 /// Response payload for `/api/play` metadata endpoints or tests.
 #[derive(Debug, Clone, Serialize)]

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -1,0 +1,43 @@
+use serde::{Deserialize, Serialize};
+
+/// Request payload for `/api/play`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct PlayRequest {
+    pub url: String,
+    #[serde(default)]
+    pub extractor: Option<String>,
+    #[serde(default)]
+    pub user_agent: Option<String>,
+    #[serde(default)]
+    pub referer: Option<String>,
+}
+
+/// Response payload for `/api/play`.
+#[derive(Debug, Clone, Serialize)]
+pub struct PlayResponse {
+    pub url: String,
+    pub referer: Option<String>,
+}
+
+/// Request payload for `/api/info`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct InfoRequest {
+    pub url: String,
+}
+
+/// Response payload for `/api/info`.
+#[derive(Debug, Clone, Serialize)]
+pub struct InfoResponse {
+    pub supported: bool,
+    pub downloader: Option<String>,
+    pub title: Option<String>,
+    pub description: Option<String>,
+    pub status: Option<String>,
+    pub year: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HealthResponse {
+    pub name: &'static str,
+    pub routes: &'static [&'static str],
+}

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use crate::api::browser::ApiBrowser;
 use crate::downloaders::SeriesCatalogInfo;
 use serde::{Deserialize, Serialize};
 
@@ -33,6 +34,7 @@ pub type PlayJson = PlayRequest;
 pub struct ApiState {
     pub download_semaphore: Arc<tokio::sync::Semaphore>,
     pub client: reqwest::Client,
+    pub browser: Arc<ApiBrowser>,
 }
 
 /// Response payload for `/api/play` metadata endpoints or tests.

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -1,9 +1,19 @@
 use serde::{Deserialize, Serialize};
 
-/// Request payload for `/api/play`.
+/// Request payload/query for `/api/play`.
 #[derive(Debug, Clone, Deserialize)]
 pub struct PlayRequest {
     pub url: String,
+    #[serde(default)]
+    pub language: Option<String>,
+    #[serde(default)]
+    pub video_type: Option<String>,
+    #[serde(default)]
+    pub episodes: Option<String>,
+    #[serde(default)]
+    pub seasons: Option<String>,
+    #[serde(default)]
+    pub extractor_priorities: Option<Vec<String>>,
     #[serde(default)]
     pub extractor: Option<String>,
     #[serde(default)]
@@ -12,7 +22,10 @@ pub struct PlayRequest {
     pub referer: Option<String>,
 }
 
-/// Response payload for `/api/play`.
+pub type PlayQuery = PlayRequest;
+pub type PlayJson = PlayRequest;
+
+/// Response payload for `/api/play` metadata endpoints or tests.
 #[derive(Debug, Clone, Serialize)]
 pub struct PlayResponse {
     pub url: String,

--- a/src/bin/sdl-api.rs
+++ b/src/bin/sdl-api.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use actix_web::{web, App, HttpServer};
+use sdl::api::browser::ApiBrowser;
 use sdl::api::types::ApiState;
 
 const DEFAULT_MAX_STREAMS: usize = 4;
@@ -22,14 +23,20 @@ async fn main() -> std::io::Result<()> {
     let state = ApiState {
         download_semaphore: Arc::new(tokio::sync::Semaphore::new(max_streams)),
         client,
+        browser: Arc::new(ApiBrowser::new()),
     };
 
-    HttpServer::new(move || {
+    let browser = state.browser.clone();
+
+    let server = HttpServer::new(move || {
         App::new()
             .app_data(web::Data::new(state.clone()))
             .configure(sdl::api::routes::configure)
     })
     .bind(bind_address)?
-    .run()
-    .await
+    .run();
+
+    let result = server.await;
+    browser.shutdown().await;
+    result
 }

--- a/src/bin/sdl-api.rs
+++ b/src/bin/sdl-api.rs
@@ -1,0 +1,11 @@
+use actix_web::{App, HttpServer};
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    let bind_address = std::env::var("SDL_API_BIND").unwrap_or_else(|_| "127.0.0.1:8080".to_owned());
+
+    HttpServer::new(|| App::new().configure(sdl::api::routes::configure))
+        .bind(bind_address)?
+        .run()
+        .await
+}

--- a/src/bin/sdl-api.rs
+++ b/src/bin/sdl-api.rs
@@ -1,11 +1,35 @@
-use actix_web::{App, HttpServer};
+use std::sync::Arc;
+use std::time::Duration;
+
+use actix_web::{web, App, HttpServer};
+use sdl::api::types::ApiState;
+
+const DEFAULT_MAX_STREAMS: usize = 4;
+const HTTP_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
     let bind_address = std::env::var("SDL_API_BIND").unwrap_or_else(|_| "127.0.0.1:8080".to_owned());
+    let max_streams = std::env::var("SDL_API_MAX_STREAMS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(DEFAULT_MAX_STREAMS);
+    let client = reqwest::ClientBuilder::new()
+        .timeout(HTTP_TIMEOUT)
+        .build()
+        .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+    let state = ApiState {
+        download_semaphore: Arc::new(tokio::sync::Semaphore::new(max_streams)),
+        client,
+    };
 
-    HttpServer::new(|| App::new().configure(sdl::api::routes::configure))
-        .bind(bind_address)?
-        .run()
-        .await
+    HttpServer::new(move || {
+        App::new()
+            .app_data(web::Data::new(state.clone()))
+            .configure(sdl::api::routes::configure)
+    })
+    .bind(bind_address)?
+    .run()
+    .await
 }

--- a/src/downloaders/aniworldserienstream.rs
+++ b/src/downloaders/aniworldserienstream.rs
@@ -22,6 +22,11 @@ static URL_REGEX: Lazy<Regex> = Lazy::new(|| {
         .unwrap()
 });
 
+/// Downloader for AniWorld/SerienStream pages.
+///
+/// This downloader requires a `thirtyfour::WebDriver` because the supported
+/// pages expose the relevant series and stream contents through a real
+/// browser/Selenium session.
 pub struct AniWorldSerienStream<'driver> {
     driver: &'driver WebDriver,
     parsed_url: ParsedUrl,

--- a/src/downloaders/aniworldserienstream.rs
+++ b/src/downloaders/aniworldserienstream.rs
@@ -18,7 +18,7 @@ use crate::downloaders::{Downloader, EpisodesRequest};
 use crate::extractors::{extract_video_url_with_extractor_from_url_unchecked, has_extractor_with_name_other_name};
 
 static URL_REGEX: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r#"(?i)^https?://(?:www\.)?(?:(aniworld)\.to/anime/stream|(s)\.to/serie|(serienstream)\.to/serie)/([^/\s]+)(?:/(?:(?:staffel-([0-9][0-9]*)(?:/(?:episode-([1-9][0-9]*)/?)?)?)|(?:(filme)(?:/(?:film-([1-9][0-9]*)/?)?)?))?)?$"#)
+    Regex::new(r#"(?i)^https?://(?:www\.)?(?:(aniworld)\.to/anime/stream|(s|sx)\.to/serie|(serienstream)\.to/serie)/([^/\s]+)(?:/(?:(?:staffel-([0-9][0-9]*)(?:/(?:episode-([1-9][0-9]*)/?)?)?)|(?:(filme)(?:/(?:film-([1-9][0-9]*)/?)?)?))?)?$"#)
         .unwrap()
 });
 
@@ -52,7 +52,7 @@ impl InstantiatedDownloader for AniWorldSerienStream<'_> {
             .execute(
                 match self.parsed_url.site {
                     Site::AniWorld => r#"return document.querySelector(".series-title > h1 > span").innerText;"#,
-                    Site::SerienStreamShort | Site::SerienStreamLong => {
+                    Site::SerienStreamShort | Site::SerienStreamX | Site::SerienStreamLong => {
                         r#"return document.querySelector("h1.fw-bold").innerText;"#
                     }
                 },
@@ -73,7 +73,7 @@ impl InstantiatedDownloader for AniWorldSerienStream<'_> {
                 None
             }
             .flatten(),
-            Site::SerienStreamShort | Site::SerienStreamLong => {
+            Site::SerienStreamShort | Site::SerienStreamX | Site::SerienStreamLong => {
                 if let Ok(element) = self.driver.find(By::Css(".series-description .description-text")).await {
                     element.text().await.ok()
                 } else {
@@ -213,6 +213,8 @@ impl TryFrom<&str> for ParsedUrl {
             Site::AniWorld
         } else if site.eq_ignore_ascii_case("s") {
             Site::SerienStreamShort
+        } else if site.eq_ignore_ascii_case("sx") {
+            Site::SerienStreamX
         } else if site.eq_ignore_ascii_case("serienstream") {
             Site::SerienStreamLong
         } else {
@@ -269,7 +271,7 @@ impl ParsedUrl {
     fn season_zero_is_filme_url(&self) -> bool {
         match self.site {
             Site::AniWorld => true,
-            Site::SerienStreamShort | Site::SerienStreamLong => false,
+            Site::SerienStreamShort | Site::SerienStreamX | Site::SerienStreamLong => false,
         }
     }
 }
@@ -278,6 +280,7 @@ impl ParsedUrl {
 enum Site {
     AniWorld,
     SerienStreamShort,
+    SerienStreamX,
     SerienStreamLong,
 }
 
@@ -286,6 +289,7 @@ impl Site {
         match self {
             Site::AniWorld => "https://aniworld.to/anime/stream",
             Site::SerienStreamShort => "https://s.to/serie",
+            Site::SerienStreamX => "https://sx.to/serie",
             Site::SerienStreamLong => "https://serienstream.to/serie",
         }
     }
@@ -457,7 +461,7 @@ impl<'driver, 'url, F: FnMut() -> Duration> Scraper<'driver, 'url, F> {
                     ),
                 ),
             ],
-            Site::SerienStreamShort | Site::SerienStreamLong => {
+            Site::SerienStreamShort | Site::SerienStreamX | Site::SerienStreamLong => {
                 [
                     (
                         VideoType::Dub(Language::German),
@@ -490,7 +494,7 @@ impl<'driver, 'url, F: FnMut() -> Duration> Scraper<'driver, 'url, F> {
                     _ => Ordering::Equal,
                 });
             }
-            Site::SerienStreamShort | Site::SerienStreamLong => {}
+            Site::SerienStreamShort | Site::SerienStreamX | Site::SerienStreamLong => {}
         }
 
         video_type.convert_to_non_unspecified_video_types_with_data(supported_video_types_and_selector)
@@ -511,7 +515,9 @@ impl<'driver, 'url, F: FnMut() -> Duration> Scraper<'driver, 'url, F> {
     async fn get_seasons_info(&self) -> Result<SeasonsInfo, anyhow::Error> {
         let seasons_selector = match self.parsed_url.site {
             Site::AniWorld => By::Css("#stream > ul:first-of-type > li"),
-            Site::SerienStreamShort | Site::SerienStreamLong => By::Css("#season-nav > ul > li > a"),
+            Site::SerienStreamShort | Site::SerienStreamX | Site::SerienStreamLong => {
+                By::Css("#season-nav > ul > li > a")
+            }
         };
         let seasons = self.driver.query(seasons_selector).all_from_selector().await.unwrap();
         let mut has_movies = false;
@@ -553,7 +559,7 @@ impl<'driver, 'url, F: FnMut() -> Duration> Scraper<'driver, 'url, F> {
     async fn get_episode_info(&self, current_season: u32, current_episode: u32) -> Option<EpisodeInfo> {
         let episode_title_selector = match self.parsed_url.site {
             Site::AniWorld => By::Css(".episodeGermanTitle"),
-            Site::SerienStreamShort | Site::SerienStreamLong => By::Css("article > h2"),
+            Site::SerienStreamShort | Site::SerienStreamX | Site::SerienStreamLong => By::Css("article > h2"),
         };
         let episode_title = if let Ok(element) = self.driver.find(episode_title_selector).await {
             element.text().await.ok().and_then(|title| {
@@ -571,7 +577,9 @@ impl<'driver, 'url, F: FnMut() -> Duration> Scraper<'driver, 'url, F> {
 
         let episodes_selector = match self.parsed_url.site {
             Site::AniWorld => By::Css("li > a[data-episode-id]"),
-            Site::SerienStreamShort | Site::SerienStreamLong => By::Css("#episode-nav > ul > li > a"),
+            Site::SerienStreamShort | Site::SerienStreamX | Site::SerienStreamLong => {
+                By::Css("#episode-nav > ul > li > a")
+            }
         };
         let episodes = self.driver.query(episodes_selector).all_from_selector().await.unwrap();
         let mut max_episode = None;
@@ -601,7 +609,7 @@ impl<'driver, 'url, F: FnMut() -> Duration> Scraper<'driver, 'url, F> {
     async fn get_language_key(&self, lang_element: &WebElement) -> Result<String, anyhow::Error> {
         let lang_key_attr = match self.parsed_url.site {
             Site::AniWorld => "data-lang-key",
-            Site::SerienStreamShort | Site::SerienStreamLong => "data-language-id",
+            Site::SerienStreamShort | Site::SerienStreamX | Site::SerienStreamLong => "data-language-id",
         };
         lang_element
             .attr(lang_key_attr)
@@ -617,7 +625,7 @@ impl<'driver, 'url, F: FnMut() -> Duration> Scraper<'driver, 'url, F> {
     ) -> Result<Vec<(String, url::Url)>, anyhow::Error> {
         let streams_selector = match self.parsed_url.site {
             Site::AniWorld => By::Css(&format!(r#".hosterSiteVideo ul li[data-lang-key="{}"]"#, lang_key)),
-            Site::SerienStreamShort | Site::SerienStreamLong => {
+            Site::SerienStreamShort | Site::SerienStreamX | Site::SerienStreamLong => {
                 By::Css(&format!(r#"button.link-box[data-language-id="{}"]"#, lang_key))
             }
         };
@@ -627,7 +635,7 @@ impl<'driver, 'url, F: FnMut() -> Duration> Scraper<'driver, 'url, F> {
         for stream in available_streams {
             let link_target_attr = match self.parsed_url.site {
                 Site::AniWorld => "data-link-target",
-                Site::SerienStreamShort | Site::SerienStreamLong => "data-play-url",
+                Site::SerienStreamShort | Site::SerienStreamX | Site::SerienStreamLong => "data-play-url",
             };
             let Some(link_target) = stream.attr(link_target_attr).await.unwrap() else {
                 log::trace!("Failed to find data-link-target");
@@ -653,7 +661,7 @@ impl<'driver, 'url, F: FnMut() -> Duration> Scraper<'driver, 'url, F> {
                     .context("failed to get name of stream platform as string")?
                     .trim()
                     .to_owned(),
-                Site::SerienStreamShort | Site::SerienStreamLong => stream
+                Site::SerienStreamShort | Site::SerienStreamX | Site::SerienStreamLong => stream
                     .attr("data-provider-name")
                     .await
                     .unwrap()
@@ -817,6 +825,8 @@ mod tests {
             "https://s.to/serie/detektiv-conan/staffel-0",
             "https://s.to/serie/detektiv-conan/staffel-5",
             "https://s.to/serie/detektiv-conan/staffel-1/episode-1",
+            "https://sx.to/serie/detektiv-conan",
+            "https://sx.to/serie/detektiv-conan/staffel-1/episode-1",
             "https://serienstream.to/serie/detektiv-conan",
             "https://serienstream.to/serie/detektiv-conan/staffel-0",
             "https://serienstream.to/serie/detektiv-conan/staffel-5",
@@ -867,8 +877,18 @@ mod tests {
             }),
         };
 
-        let url5 = "https://serienstream.to/serie/detektiv-conan/staffel-19/episode-20";
+        let url5 = "https://sx.to/serie/detektiv-conan/staffel-19/episode-20";
         let expected5 = ParsedUrl {
+            site: Site::SerienStreamX,
+            name: "detektiv-conan".to_string(),
+            season: Some(ParsedUrlSeason {
+                season: 19,
+                episode: Some(20),
+            }),
+        };
+
+        let url6 = "https://serienstream.to/serie/detektiv-conan/staffel-19/episode-20";
+        let expected6 = ParsedUrl {
             site: Site::SerienStreamLong,
             name: "detektiv-conan".to_string(),
             season: Some(ParsedUrlSeason {
@@ -877,8 +897,8 @@ mod tests {
             }),
         };
 
-        let url6 = "https://serienstream.to/serie/detektiv-conan/staffel-0/episode-3";
-        let expected6 = ParsedUrl {
+        let url7 = "https://serienstream.to/serie/detektiv-conan/staffel-0/episode-3";
+        let expected7 = ParsedUrl {
             site: Site::SerienStreamLong,
             name: "detektiv-conan".to_string(),
             season: Some(ParsedUrlSeason {
@@ -894,6 +914,7 @@ mod tests {
             (url4, expected4),
             (url5, expected5),
             (url6, expected6),
+            (url7, expected7),
         ];
 
         for (input, output) in tests {

--- a/src/downloaders/aniworldserienstream.rs
+++ b/src/downloaders/aniworldserienstream.rs
@@ -9,8 +9,9 @@ use thirtyfour::{By, WebDriver, WebElement};
 use tokio::sync::mpsc::UnboundedSender;
 
 use super::{
-    AllOrSpecific, DownloadRequest, DownloadSettings, DownloadTask, EpisodeInfo, EpisodeNumber, ExtractorMatch,
-    InstantiatedDownloader, Language, SeriesInfo, VideoType,
+    AllOrSpecific, AvailableStreamInfo, DownloadRequest, DownloadSettings, DownloadTask, EpisodeCatalogInfo,
+    EpisodeInfo, EpisodeNumber, ExtractorMatch, InfoRequest, InstantiatedDownloader, Language, SeasonCatalogInfo,
+    SeriesCatalogInfo, SeriesInfo, VideoType,
 };
 use crate::downloaders::utils::sleep_random;
 use crate::downloaders::{Downloader, EpisodesRequest};
@@ -90,6 +91,77 @@ impl InstantiatedDownloader for AniWorldSerienStream<'_> {
             description,
             status: None,
             year: None,
+        })
+    }
+
+    async fn get_catalog_info(&self, request: InfoRequest) -> Result<SeriesCatalogInfo, anyhow::Error> {
+        let series_info = self.get_series_info().await?;
+
+        let target_season = self.parsed_url.season.as_ref().map(|season| season.season).unwrap_or(1);
+        let target_episode = self
+            .parsed_url
+            .season
+            .as_ref()
+            .and_then(|season| season.episode)
+            .unwrap_or(1);
+        self.driver
+            .goto(self.parsed_url.get_episode_url(target_season, target_episode))
+            .await
+            .context("failed to go to episode page")?;
+        sleep_random(1000..=2000).await;
+
+        let helper_request = DownloadRequest {
+            language: VideoType::Unspecified(Language::Unspecified),
+            episodes: EpisodesRequest::Unspecified,
+            extractor_priorities: vec![ExtractorMatch::Any],
+        };
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let settings = DownloadSettings::new(None, || Duration::ZERO);
+        let helper = Scraper::new(self.driver, &self.parsed_url, helper_request, settings, tx)?;
+        let seasons_info = helper.get_seasons_info().await.ok();
+        let episode_info = helper
+            .get_episode_info(target_season, target_episode)
+            .await
+            .context("failed to get episode info")?;
+        let hosters = helper
+            .collect_available_stream_infos_for_all_languages(request.resolve_streams)
+            .await?;
+        let mut languages = hosters.iter().map(|stream| stream.language.clone()).collect::<Vec<_>>();
+        languages.sort();
+        languages.dedup();
+
+        let max_season = seasons_info
+            .as_ref()
+            .map(|info| info.max_season)
+            .unwrap_or(target_season);
+        let season_start = if seasons_info.as_ref().is_some_and(|info| info.has_season_zero) {
+            0
+        } else {
+            1
+        };
+        let mut seasons = (season_start..=max_season)
+            .map(|season_number| SeasonCatalogInfo {
+                season_number,
+                episodes: Vec::new(),
+            })
+            .collect::<Vec<_>>();
+
+        if let Some(season) = seasons.iter_mut().find(|season| season.season_number == target_season) {
+            season.episodes.push(EpisodeCatalogInfo {
+                season_number: target_season,
+                episode_number: target_episode,
+                episode_title: episode_info.name,
+                languages,
+                hosters,
+            });
+        }
+
+        Ok(SeriesCatalogInfo {
+            title: series_info.title,
+            description: series_info.description,
+            status: series_info.status.map(|status| format!("{status:?}")),
+            year: series_info.year,
+            seasons,
         })
     }
 
@@ -521,29 +593,23 @@ impl<'driver, 'url, F: FnMut() -> Duration> Scraper<'driver, 'url, F> {
         })
     }
 
-    async fn send_stream_to_downloader(
-        &mut self,
-        current_season: u32,
-        current_episode: u32,
-    ) -> Result<(), anyhow::Error> {
-        let episode_info = self
-            .get_episode_info(current_season, current_episode)
-            .await
-            .context("failed to get episode info")?;
-        let (video_type, lang_element) = self
-            .get_language_element()
-            .await
-            .context("failed to find episode in requested language")?;
-
+    async fn get_language_key(&self, lang_element: &WebElement) -> Result<String, anyhow::Error> {
         let lang_key_attr = match self.parsed_url.site {
             Site::AniWorld => "data-lang-key",
             Site::SerienStreamShort | Site::SerienStreamLong => "data-language-id",
         };
-        let lang_key = lang_element
+        lang_element
             .attr(lang_key_attr)
             .await
-            .unwrap()
-            .context("failed to find data-lang")?;
+            .context("failed to read language key")?
+            .context("failed to find data-lang")
+    }
+
+    async fn collect_available_stream_platforms(
+        &self,
+        lang_key: &str,
+        current_url: &url::Url,
+    ) -> Result<Vec<(String, url::Url)>, anyhow::Error> {
         let streams_selector = match self.parsed_url.site {
             Site::AniWorld => By::Css(&format!(r#".hosterSiteVideo ul li[data-lang-key="{}"]"#, lang_key)),
             Site::SerienStreamShort | Site::SerienStreamLong => {
@@ -551,14 +617,7 @@ impl<'driver, 'url, F: FnMut() -> Duration> Scraper<'driver, 'url, F> {
             }
         };
         let available_streams = self.driver.query(streams_selector).all_from_selector().await.unwrap();
-
-        if available_streams.is_empty() {
-            anyhow::bail!("no streams in requested language available");
-        }
-
-        // Get all available stream platforms with name and url
-        let current_url = self.driver.current_url().await.unwrap();
-        let mut stream_platform_name_and_redirect_link = Vec::with_capacity(available_streams.len());
+        let mut stream_platforms = Vec::with_capacity(available_streams.len());
 
         for stream in available_streams {
             let link_target_attr = match self.parsed_url.site {
@@ -576,25 +635,102 @@ impl<'driver, 'url, F: FnMut() -> Duration> Scraper<'driver, 'url, F> {
             };
 
             let stream_platform_name = match self.parsed_url.site {
-                Site::AniWorld => {
-                    self.driver
-                        .execute(
-                            &format!(r#"return document.querySelector('.hosterSiteVideo ul li[data-lang-key="{}"][data-link-target="{}"] h4').innerText;"#, lang_key, link_target),
-                            vec![],
-                        )
-                        .await
-                        .context("failed to get name of stream platform")?
-                        .json()
-                        .as_str().context("failed to get name of stream platform as string")?
-                        .trim()
-                        .to_owned()
-                }
-                Site::SerienStreamShort | Site::SerienStreamLong => {
-                    stream.attr("data-provider-name").await.unwrap().context("failed to get name of stream platform")?
-                }
+                Site::AniWorld => self
+                    .driver
+                    .execute(
+                        &format!(r#"return document.querySelector('.hosterSiteVideo ul li[data-lang-key="{}"][data-link-target="{}"] h4').innerText;"#, lang_key, link_target),
+                        vec![],
+                    )
+                    .await
+                    .context("failed to get name of stream platform")?
+                    .json()
+                    .as_str()
+                    .context("failed to get name of stream platform as string")?
+                    .trim()
+                    .to_owned(),
+                Site::SerienStreamShort | Site::SerienStreamLong => stream
+                    .attr("data-provider-name")
+                    .await
+                    .unwrap()
+                    .context("failed to get name of stream platform")?,
             };
 
-            stream_platform_name_and_redirect_link.push((stream_platform_name, redirect_link));
+            stream_platforms.push((stream_platform_name, redirect_link));
+        }
+
+        Ok(stream_platforms)
+    }
+
+    async fn collect_available_stream_infos_for_all_languages(
+        &self,
+        resolve_streams: bool,
+    ) -> Result<Vec<AvailableStreamInfo>, anyhow::Error> {
+        let current_url = self.driver.current_url().await.unwrap();
+        let mut infos = Vec::new();
+
+        for (video_type, selector) in
+            Self::get_language_selectors(&self.parsed_url.site, &VideoType::Unspecified(Language::Unspecified))
+                .unwrap_or_default()
+        {
+            let Ok(lang_element) = self.driver.find(selector).await else {
+                continue;
+            };
+            let lang_key = self.get_language_key(&lang_element).await?;
+            for (stream_platform_name, redirect_link) in
+                self.collect_available_stream_platforms(&lang_key, &current_url).await?
+            {
+                let (resolved_url, referer, error) = if resolve_streams {
+                    match extract_video_url_with_extractor_from_url_unchecked(
+                        redirect_link.as_str(),
+                        &stream_platform_name,
+                        None,
+                        Some(current_url.as_str().to_owned()),
+                    )
+                    .await
+                    {
+                        Some(Ok(extracted)) => (Some(extracted.url), extracted.referer, None),
+                        Some(Err(err)) => (None, None, Some(format!("{err:#}"))),
+                        None => (None, None, Some(format!("no extractor for {stream_platform_name}"))),
+                    }
+                } else {
+                    (None, None, None)
+                };
+
+                infos.push(AvailableStreamInfo {
+                    name: stream_platform_name,
+                    language: video_type.to_string(),
+                    redirect_link: redirect_link.to_string(),
+                    resolved_url,
+                    referer,
+                    error,
+                });
+            }
+        }
+
+        Ok(infos)
+    }
+
+    async fn send_stream_to_downloader(
+        &mut self,
+        current_season: u32,
+        current_episode: u32,
+    ) -> Result<(), anyhow::Error> {
+        let episode_info = self
+            .get_episode_info(current_season, current_episode)
+            .await
+            .context("failed to get episode info")?;
+        let (video_type, lang_element) = self
+            .get_language_element()
+            .await
+            .context("failed to find episode in requested language")?;
+
+        let lang_key = self.get_language_key(&lang_element).await?;
+        let current_url = self.driver.current_url().await.unwrap();
+        let mut stream_platform_name_and_redirect_link =
+            self.collect_available_stream_platforms(&lang_key, &current_url).await?;
+
+        if stream_platform_name_and_redirect_link.is_empty() {
+            anyhow::bail!("no streams in requested language available");
         }
 
         // Order the stream platforms

--- a/src/downloaders/mod.rs
+++ b/src/downloaders/mod.rs
@@ -6,10 +6,50 @@ use std::time::Duration;
 use clap::ValueEnum;
 use enum_dispatch::enum_dispatch;
 use enum_iterator::Sequence;
+use serde::Serialize;
 use tokio::sync::mpsc::UnboundedSender;
 
 use self::aniworldserienstream::AniWorldSerienStream;
 use crate::extractors::ExtractedVideo;
+
+#[derive(Debug, Clone, Default)]
+pub struct InfoRequest {
+    pub resolve_streams: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SeriesCatalogInfo {
+    pub title: String,
+    pub description: Option<String>,
+    pub status: Option<String>,
+    pub year: Option<u32>,
+    pub seasons: Vec<SeasonCatalogInfo>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SeasonCatalogInfo {
+    pub season_number: u32,
+    pub episodes: Vec<EpisodeCatalogInfo>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct EpisodeCatalogInfo {
+    pub season_number: u32,
+    pub episode_number: u32,
+    pub episode_title: Option<String>,
+    pub languages: Vec<String>,
+    pub hosters: Vec<AvailableStreamInfo>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AvailableStreamInfo {
+    pub name: String,
+    pub language: String,
+    pub redirect_link: String,
+    pub resolved_url: Option<String>,
+    pub referer: Option<String>,
+    pub error: Option<String>,
+}
 
 pub mod aniworldserienstream;
 
@@ -328,6 +368,8 @@ pub enum EpisodeNumber {
 #[enum_dispatch]
 pub trait InstantiatedDownloader {
     async fn get_series_info(&self) -> Result<SeriesInfo, anyhow::Error>;
+
+    async fn get_catalog_info(&self, request: InfoRequest) -> Result<SeriesCatalogInfo, anyhow::Error>;
 
     async fn download<F: FnMut() -> Duration>(
         &self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(warnings, unused)]
 
+pub mod api;
 pub(crate) mod download;
 pub mod downloaders;
 pub mod extractors;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 #![allow(warnings, unused)]
 
 pub mod api;
+pub(crate) mod chrome;
+pub(crate) mod dirs;
 pub(crate) mod download;
 pub mod downloaders;
 pub mod extractors;


### PR DESCRIPTION
##  Changes

* Added /api/download GET/POST routing and handlers, reusing the existing playable-video resolution flow while returning streamed responses with attachment content disposition for proper file downloads. 

* Added /api/info_resolve GET/POST routing, request/response types, and resolver logic for generic redirect links such as s.to/r, sx.to/r, and aniworld.to/redirect, resolving them to extractor-backed video URLs when possible. 

* Added support for generic redirect URLs in the /api/play and /api/download resolution path, so unsupported direct URLs can first be followed to their real hoster URL and then extracted. 

* Added sx.to as a supported SerienStream host variant with URL parsing, base URL handling, and test coverage alongside s.to and serienstream.to. 

* Added and served an OpenAPI 3.1.1 YAML document at /openapi.yaml, including the new /api/download and /api/info_resolve endpoints for ChatGPT Actions compatibility.